### PR TITLE
I/5755: Restricted editing mode conversion

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@ckeditor/ckeditor5-engine": "^15.0.0",
     "@ckeditor/ckeditor5-paragraph": "^15.0.0",
     "@ckeditor/ckeditor5-table": "^15.0.0",
-	"@ckeditor/ckeditor5-utils": "^15.0.0",
+    "@ckeditor/ckeditor5-utils": "^15.0.0",
     "eslint": "^5.5.0",
     "eslint-config-ckeditor5": "^2.0.0",
     "husky": "^2.4.1",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@ckeditor/ckeditor5-engine": "^15.0.0",
     "@ckeditor/ckeditor5-paragraph": "^15.0.0",
     "@ckeditor/ckeditor5-table": "^15.0.0",
+	"@ckeditor/ckeditor5-utils": "^15.0.0",
     "eslint": "^5.5.0",
     "eslint-config-ckeditor5": "^2.0.0",
     "husky": "^2.4.1",

--- a/src/restrictedediting.js
+++ b/src/restrictedediting.js
@@ -1,0 +1,22 @@
+/**
+ * @license Copyright (c) 2003-2019, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/**
+ * @module restricted-editing/restrictedediting
+ */
+
+import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
+
+/**
+ * @extends module:core/plugin~Plugin
+ */
+export default class RestrictedEditing extends Plugin {
+	/**
+	 * @inheritDoc
+	 */
+	static get pluginName() {
+		return 'RestrictedEditing';
+	}
+}

--- a/src/restrictedediting.js
+++ b/src/restrictedediting.js
@@ -19,4 +19,19 @@ export default class RestrictedEditing extends Plugin {
 	static get pluginName() {
 		return 'RestrictedEditing';
 	}
+
+	/**
+	 * @inheritDoc
+	 */
+	init() {
+		const editor = this.editor;
+
+		editor.conversion.for( 'downcast' ).markerToHighlight( {
+			model: 'restricted-editing-exception',
+			view: {
+				name: 'span',
+				classes: 'ck-restricted-editing-exception'
+			}
+		} );
+	}
 }

--- a/src/restrictedediting.js
+++ b/src/restrictedediting.js
@@ -43,11 +43,12 @@ export default class RestrictedEditing extends Plugin {
 
 		editor.conversion.for( 'downcast' ).markerToHighlight( {
 			model: 'restricted-editing-exception',
-			view: {
+			// Use callback to return new object every time new marker instance is created - otherwise it will be seen as the same marker.
+			view: () => ( {
 				name: 'span',
 				classes: 'ck-restricted-editing-exception',
 				priority: -10
-			}
+			} )
 		} );
 	}
 }

--- a/src/restrictedediting.js
+++ b/src/restrictedediting.js
@@ -45,7 +45,8 @@ export default class RestrictedEditing extends Plugin {
 			model: 'restricted-editing-exception',
 			view: {
 				name: 'span',
-				classes: 'ck-restricted-editing-exception'
+				classes: 'ck-restricted-editing-exception',
+				priority: -10
 			}
 		} );
 	}

--- a/src/restrictededitingexceptionediting.js
+++ b/src/restrictededitingexceptionediting.js
@@ -29,11 +29,21 @@ export default class RestrictedEditingExceptionEditing extends Plugin {
 
 		editor.model.schema.extend( '$text', { allowAttributes: [ 'restrictedEditingException' ] } );
 
-		editor.conversion.attributeToElement( {
+		editor.conversion.for( 'upcast' ).elementToAttribute( {
 			model: 'restrictedEditingException',
 			view: {
 				name: 'span',
 				classes: 'ck-restricted-editing-exception'
+			}
+		} );
+
+		editor.conversion.for( 'downcast' ).attributeToElement( {
+			model: 'restrictedEditingException',
+			view: ( modelAttributeValue, viewWriter ) => {
+				if ( modelAttributeValue ) {
+					// Make the restricted editing <span> outer-most in the view.
+					return viewWriter.createAttributeElement( 'span', { class: 'ck-restricted-editing-exception' }, { priority: -10 } );
+				}
 			}
 		} );
 

--- a/tests/manual/restrictedediting.html
+++ b/tests/manual/restrictedediting.html
@@ -1,3 +1,8 @@
+<p>
+	<button id="mode-standard">Standard mode</button>
+	<button id="mode-restricted">Restricted mode</button>
+</p>
+
 <div id="editor">
 	<h2>Heading 1</h2>
 	<p>Paragraph <span class="ck-restricted-editing-exception">it is editable</span></p>

--- a/tests/manual/restrictedediting.html
+++ b/tests/manual/restrictedediting.html
@@ -1,7 +1,9 @@
 <p>
-	<button id="mode-standard">Standard mode</button>
-	<button id="mode-restricted">Restricted mode</button>
+	<button id="mode-standard">Switch to standard mode</button>
+	<button id="mode-restricted">Switch to restricted mode</button>
 </p>
+
+<p id="current-mode"></p>
 
 <div id="editor">
 	<h2>Heading 1</h2>
@@ -32,5 +34,23 @@
 <style>
 	.ck-restricted-editing-exception {
 		background-color: #ffcd96;
+	}
+
+	#current-mode {
+		/*text-align: center;*/
+		padding: 1em 0;
+	}
+
+	.mode {
+		color: #fff;
+		padding: 0.5em;
+	}
+
+	.mode-standard {
+		background: #4f4fff;
+	}
+
+	.mode-restricted {
+		background: #a72727;
 	}
 </style>

--- a/tests/manual/restrictedediting.js
+++ b/tests/manual/restrictedediting.js
@@ -60,7 +60,7 @@ async function startRestrictedMode() {
 
 	await reloadEditor( {
 		plugins: [ ArticlePluginSet, Table, RestrictedEditing ],
-		toolbar: [ 'bold', 'italic', 'link', 'underline', '|', 'restrictedEditing', '|', 'undo', 'redo' ]
+		toolbar: [ 'bold', 'italic', 'link', '|', 'restrictedEditing', '|', 'undo', 'redo' ]
 	} );
 
 	enableSwitchToStandardMode();

--- a/tests/manual/restrictedediting.js
+++ b/tests/manual/restrictedediting.js
@@ -14,6 +14,7 @@ import RestrictedEditing from '../../src/restrictedediting';
 
 const restrictedModeButton = document.getElementById( 'mode-restricted' );
 const standardModeButton = document.getElementById( 'mode-standard' );
+const currentModeDisplay = document.getElementById( 'current-mode' );
 
 enableSwitchToStandardMode();
 enableSwitchToRestrictedMode();
@@ -51,6 +52,7 @@ async function startStandardMode() {
 		}
 	} );
 
+	currentModeDisplay.innerHTML = 'Current Mode: <span class="mode mode-standard">STANDARD</span>';
 	enableSwitchToRestrictedMode();
 }
 
@@ -63,6 +65,7 @@ async function startRestrictedMode() {
 		toolbar: [ 'bold', 'italic', 'link', '|', 'restrictedEditing', '|', 'undo', 'redo' ]
 	} );
 
+	currentModeDisplay.innerHTML = 'Current Mode: <span class="mode mode-restricted">RESTRICTED</span>';
 	enableSwitchToStandardMode();
 }
 

--- a/tests/manual/restrictedediting.js
+++ b/tests/manual/restrictedediting.js
@@ -10,6 +10,7 @@ import ArticlePluginSet from '@ckeditor/ckeditor5-core/tests/_utils/articleplugi
 import Table from '@ckeditor/ckeditor5-table/src/table';
 
 import RestrictedEditingException from '../../src/restrictededitingexception';
+import RestrictedEditing from '../../src/restrictedediting';
 
 const restrictedModeButton = document.getElementById( 'mode-restricted' );
 const standardModeButton = document.getElementById( 'mode-standard' );
@@ -31,7 +32,24 @@ async function startStandardMode() {
 	standardModeButton.removeEventListener( 'click', startStandardMode );
 	standardModeButton.setAttribute( 'disabled', 'disabled' );
 
-	window.editor = await getEditor( [ ArticlePluginSet, Table, RestrictedEditingException ] );
+	await reloadEditor( {
+		plugins: [ ArticlePluginSet, Table, RestrictedEditingException ],
+		toolbar: [
+			'heading', '|', 'bold', 'italic', 'link', '|',
+			'bulletedList', 'numberedList', 'blockQuote', 'insertTable', '|',
+			'restrictedEditingException', '|', 'undo', 'redo'
+		],
+		image: {
+			toolbar: [ 'imageStyle:full', 'imageStyle:side', '|', 'imageTextAlternative' ]
+		},
+		table: {
+			contentToolbar: [
+				'tableColumn',
+				'tableRow',
+				'mergeTableCells'
+			]
+		}
+	} );
 
 	enableSwitchToRestrictedMode();
 }
@@ -40,35 +58,18 @@ async function startRestrictedMode() {
 	restrictedModeButton.removeEventListener( 'click', startRestrictedMode );
 	restrictedModeButton.setAttribute( 'disabled', 'disabled' );
 
-	window.editor = await getEditor( [ ArticlePluginSet, Table, RestrictedEditingException ] );
+	await reloadEditor( {
+		plugins: [ ArticlePluginSet, Table, RestrictedEditing ],
+		toolbar: [ 'bold', 'italic', 'link', 'underline', '|', 'restrictedEditing', '|', 'undo', 'redo' ]
+	} );
 
 	enableSwitchToStandardMode();
 }
 
-async function getEditor( plugins ) {
+async function reloadEditor( config ) {
 	if ( window.editor ) {
 		await window.editor.destroy();
 	}
 
-	// await new Promise( resolve => setTimeout( resolve, 1000 ) );
-
-	return await ClassicEditor
-		.create( document.querySelector( '#editor' ), {
-			plugins,
-			toolbar: [ 'heading', '|',
-				'bold', 'italic', 'link', '|',
-				'bulletedList', 'numberedList', 'blockQuote', 'insertTable', '|',
-				'restrictedEditingException', '|', 'undo', 'redo'
-			],
-			image: {
-				toolbar: [ 'imageStyle:full', 'imageStyle:side', '|', 'imageTextAlternative' ]
-			},
-			table: {
-				contentToolbar: [
-					'tableColumn',
-					'tableRow',
-					'mergeTableCells'
-				]
-			}
-		} );
+	window.editor = await ClassicEditor.create( document.querySelector( '#editor' ), config );
 }

--- a/tests/manual/restrictedediting.js
+++ b/tests/manual/restrictedediting.js
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
-/* globals console, window, document */
+/* globals window, document */
 
 import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
 import ArticlePluginSet from '@ckeditor/ckeditor5-core/tests/_utils/articlepluginset';
@@ -11,28 +11,64 @@ import Table from '@ckeditor/ckeditor5-table/src/table';
 
 import RestrictedEditingException from '../../src/restrictededitingexception';
 
-ClassicEditor
-	.create( document.querySelector( '#editor' ), {
-		plugins: [ ArticlePluginSet, Table, RestrictedEditingException ],
-		toolbar: [ 'heading', '|',
-			'bold', 'italic', 'link', '|',
-			'bulletedList', 'numberedList', 'blockQuote', 'insertTable', '|',
-			'restrictedEditingException', '|', 'undo', 'redo'
-		],
-		image: {
-			toolbar: [ 'imageStyle:full', 'imageStyle:side', '|', 'imageTextAlternative' ]
-		},
-		table: {
-			contentToolbar: [
-				'tableColumn',
-				'tableRow',
-				'mergeTableCells'
-			]
-		}
-	} )
-	.then( editor => {
-		window.editor = editor;
-	} )
-	.catch( err => {
-		console.error( err.stack );
-	} );
+const restrictedModeButton = document.getElementById( 'mode-restricted' );
+const standardModeButton = document.getElementById( 'mode-standard' );
+
+enableSwitchToStandardMode();
+enableSwitchToRestrictedMode();
+
+function enableSwitchToRestrictedMode() {
+	restrictedModeButton.removeAttribute( 'disabled' );
+	restrictedModeButton.addEventListener( 'click', startRestrictedMode );
+}
+
+function enableSwitchToStandardMode() {
+	standardModeButton.removeAttribute( 'disabled' );
+	standardModeButton.addEventListener( 'click', startStandardMode );
+}
+
+async function startStandardMode() {
+	standardModeButton.removeEventListener( 'click', startStandardMode );
+	standardModeButton.setAttribute( 'disabled', 'disabled' );
+
+	window.editor = await getEditor( [ ArticlePluginSet, Table, RestrictedEditingException ] );
+
+	enableSwitchToRestrictedMode();
+}
+
+async function startRestrictedMode() {
+	restrictedModeButton.removeEventListener( 'click', startRestrictedMode );
+	restrictedModeButton.setAttribute( 'disabled', 'disabled' );
+
+	window.editor = await getEditor( [ ArticlePluginSet, Table, RestrictedEditingException ] );
+
+	enableSwitchToStandardMode();
+}
+
+async function getEditor( plugins ) {
+	if ( window.editor ) {
+		await window.editor.destroy();
+	}
+
+	// await new Promise( resolve => setTimeout( resolve, 1000 ) );
+
+	return await ClassicEditor
+		.create( document.querySelector( '#editor' ), {
+			plugins,
+			toolbar: [ 'heading', '|',
+				'bold', 'italic', 'link', '|',
+				'bulletedList', 'numberedList', 'blockQuote', 'insertTable', '|',
+				'restrictedEditingException', '|', 'undo', 'redo'
+			],
+			image: {
+				toolbar: [ 'imageStyle:full', 'imageStyle:side', '|', 'imageTextAlternative' ]
+			},
+			table: {
+				contentToolbar: [
+					'tableColumn',
+					'tableRow',
+					'mergeTableCells'
+				]
+			}
+		} );
+}

--- a/tests/manual/restrictedediting.md
+++ b/tests/manual/restrictedediting.md
@@ -2,3 +2,8 @@
 
 1. The editor data should be loaded with "it is editable" fragment marked as an exception in the first paragraph (orange-ish background).
 2. Test the "Restricted editing" button to mark parts of text as non-restricted.
+
+## Restricted editing - Restricted mode
+
+1. The editor data should be loaded with the same exception fragments as defined in standard mode.
+2. The editor toolbar should have limited set of buttons for basic styles.

--- a/tests/restrictedediting.js
+++ b/tests/restrictedediting.js
@@ -54,6 +54,19 @@ describe( 'RestrictedEditing', () => {
 			return editor.destroy();
 		} );
 
+		describe( 'upcast', () => {
+			it( 'should convert <span class="ck-restricted-editing-exception"> to marker', () => {
+				editor.setData( '<p>foo <span class="ck-restricted-editing-exception">bar</span> baz</p>' );
+
+				expect( model.markers.has( 'restricted-editing-exception:1' ) ).to.be.true;
+
+				const marker = model.markers.get( 'restricted-editing-exception:1' );
+
+				expect( marker.getStart().path ).to.deep.equal( [ 0, 4 ] );
+				expect( marker.getEnd().path ).to.deep.equal( [ 0, 7 ] );
+			} );
+		} );
+
 		describe( 'downcast', () => {
 			it( 'should convert model marker to <span>', () => {
 				setModelData( model, '<paragraph>foo bar baz</paragraph>' );

--- a/tests/restrictedediting.js
+++ b/tests/restrictedediting.js
@@ -65,6 +65,22 @@ describe( 'RestrictedEditing', () => {
 				expect( marker.getStart().path ).to.deep.equal( [ 0, 4 ] );
 				expect( marker.getEnd().path ).to.deep.equal( [ 0, 7 ] );
 			} );
+
+			it( 'should convert multiple <span class="ck-restricted-editing-exception">', () => {
+				editor.setData(
+					'<p>foo <span class="ck-restricted-editing-exception">bar</span> baz</p>' +
+					'<p>ABCDEF<span class="ck-restricted-editing-exception">GHIJK</span>LMNOPQRST</p>'
+				);
+
+				expect( model.markers.has( 'restricted-editing-exception:1' ) ).to.be.true;
+				expect( model.markers.has( 'restricted-editing-exception:2' ) ).to.be.true;
+
+				// Data for the first marker is the same as in previous tests so no need to test it again.
+				const secondMarker = model.markers.get( 'restricted-editing-exception:2' );
+
+				expect( secondMarker.getStart().path ).to.deep.equal( [ 1, 6 ] );
+				expect( secondMarker.getEnd().path ).to.deep.equal( [ 1, 11 ] );
+			} );
 		} );
 
 		describe( 'downcast', () => {

--- a/tests/restrictedediting.js
+++ b/tests/restrictedediting.js
@@ -9,7 +9,7 @@ import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
 import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor';
 
 import RestrictedEditing from './../src/restrictedediting';
-import { getData as getModelData, setData as setModelData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
+import { setData as setModelData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
 import { getData as getViewData } from '@ckeditor/ckeditor5-engine/src/dev-utils/view';
 import VirtualTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/virtualtesteditor';
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';

--- a/tests/restrictedediting.js
+++ b/tests/restrictedediting.js
@@ -81,6 +81,12 @@ describe( 'RestrictedEditing', () => {
 				expect( secondMarker.getStart().path ).to.deep.equal( [ 1, 6 ] );
 				expect( secondMarker.getEnd().path ).to.deep.equal( [ 1, 11 ] );
 			} );
+
+			it( 'should not convert other <span> elements', () => {
+				editor.setData( '<p>foo <span class="foo bar">bar</span> baz</p>' );
+
+				expect( model.markers.has( 'restricted-editing-exception:1' ) ).to.be.false;
+			} );
 		} );
 
 		describe( 'downcast', () => {

--- a/tests/restrictedediting.js
+++ b/tests/restrictedediting.js
@@ -107,6 +107,25 @@ describe( 'RestrictedEditing', () => {
 				expect( editor.getData() ).to.equal( expectedView );
 				expect( getViewData( editor.editing.view, { withoutSelection: true } ) ).to.equal( expectedView );
 			} );
+
+			it( 'converted <span> should be the outermost attribute element', () => {
+				editor.conversion.for( 'downcast' ).attributeToElement( { model: 'bold', view: 'b' } );
+				setModelData( model, '<paragraph><$text bold="true">foo bar baz</$text></paragraph>' );
+
+				const paragraph = model.document.getRoot().getChild( 0 );
+
+				model.change( writer => {
+					writer.addMarker( 'restricted-editing-exception:1', {
+						range: writer.createRange( writer.createPositionAt( paragraph, 0 ), writer.createPositionAt( paragraph, 'end' ) ),
+						usingOperation: true,
+						affectsData: true
+					} );
+				} );
+
+				const expectedView = '<p><span class="ck-restricted-editing-exception"><b>foo bar baz</b></span></p>';
+				expect( editor.getData() ).to.equal( expectedView );
+				expect( getViewData( editor.editing.view, { withoutSelection: true } ) ).to.equal( expectedView );
+			} );
 		} );
 	} );
 } );

--- a/tests/restrictedediting.js
+++ b/tests/restrictedediting.js
@@ -1,0 +1,38 @@
+/**
+ * @license Copyright (c) 2003-2019, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/* global document */
+
+import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
+import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor';
+
+import RestrictedEditing from './../src/restrictedediting';
+
+describe( 'RestrictedEditing', () => {
+	let editor, element;
+
+	testUtils.createSinonSandbox();
+
+	beforeEach( async () => {
+		element = document.createElement( 'div' );
+		document.body.appendChild( element );
+
+		editor = await ClassicTestEditor.create( element, { plugins: [ RestrictedEditing ] } );
+	} );
+
+	afterEach( () => {
+		element.remove();
+
+		return editor.destroy();
+	} );
+
+	it( 'should be named', () => {
+		expect( RestrictedEditing.pluginName ).to.equal( 'RestrictedEditing' );
+	} );
+
+	it( 'should be loaded', () => {
+		expect( editor.plugins.get( RestrictedEditing ) ).to.be.instanceOf( RestrictedEditing );
+	} );
+} );

--- a/tests/restrictededitingexceptionediting.js
+++ b/tests/restrictededitingexceptionediting.js
@@ -11,6 +11,7 @@ import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
 
 import RestrictedEditingExceptionEditing from '../src/restrictededitingexceptionediting';
 import RestrictedEditingExceptionCommand from '../src/restrictededitingexceptioncommand';
+import { assertEqualMarkup } from '@ckeditor/ckeditor5-utils/tests/_utils/utils';
 
 describe( 'RestrictedEditingExceptionEditing', () => {
 	let editor, model;
@@ -69,6 +70,31 @@ describe( 'RestrictedEditingExceptionEditing', () => {
 
 				expect( editor.getData() ).to.equal( expectedView );
 				expect( getViewData( editor.editing.view, { withoutSelection: true } ) ).to.equal( expectedView );
+			} );
+
+			it( 'converted <span> should be outer most element', () => {
+				editor.conversion.for( 'downcast' ).attributeToElement( {
+					model: 'bold',
+					view: 'b'
+				} );
+				editor.conversion.for( 'downcast' ).attributeToElement( {
+					model: 'italic',
+					view: 'i'
+				} );
+
+				const expectedView = '<p><span class="ck-restricted-editing-exception"><b>foo</b> <i>bar</i> baz</span></p>';
+
+				setModelData( editor.model,
+					'<paragraph>' +
+						'<$text restrictedEditingException="true" bold="true">foo</$text>' +
+						'<$text restrictedEditingException="true"> </$text>' +
+						'<$text restrictedEditingException="true" italic="true">bar</$text>' +
+						'<$text restrictedEditingException="true"> baz</$text>' +
+					'</paragraph>'
+				);
+
+				assertEqualMarkup( editor.getData(), expectedView );
+				assertEqualMarkup( getViewData( editor.editing.view, { withoutSelection: true } ), expectedView );
 			} );
 		} );
 	} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Implemented the plugin that enables a "restricted" mode of the restricted editing. Closes ckeditor/ckeditor5#5755.

---

### Additional information

This PR implements part of the editing part of the restricted editing feature:
- added the manual tests improvements with switching modes (two editors)
- conversion for restricted editing mode using markers (created to be a bit future compatible with UpcastHelpers methods - possibility to add a upcast conversion helper `highlightToMarker()`)
