### PR TITLE
I/5840: Enforce restricted editing restrictions

### DIFF
--- a/src/restrictededitingmodeediting.js
+++ b/src/restrictededitingmodeediting.js
@@ -76,6 +76,7 @@ export default class RestrictedEditingModeEditing extends Plugin {
 
 		this._setupConversion();
 		this._setupCommandsToggling();
+		this._setupRestrictions();
 
 		// Commands & keystrokes that allow navigation in the content.
 		editor.commands.add( 'goToPreviousRestrictedEditingException', new RestrictedEditingNavigationCommand( editor, 'backward' ) );
@@ -162,8 +163,14 @@ export default class RestrictedEditingModeEditing extends Plugin {
 		doc.registerPostFixer( extendMarkerOnTypingPostFixer( editor ) );
 		doc.registerPostFixer( resurrectCollapsedMarkerPostFixer( editor ) );
 
-		this.listenTo( model, 'deleteContent', restrictDeleteContent( editor ), { priority: 'high' } );
-		this.listenTo( model, 'applyOperation', restrictAttributeOperation( editor ), { priority: 'high' } );
+		setupExceptionHighlighting( editor );
+	}
+
+	_setupRestrictions() {
+		const editor = this.editor;
+
+		this.listenTo( editor.model, 'deleteContent', restrictDeleteContent( editor ), { priority: 'high' } );
+		this.listenTo( editor.model, 'applyOperation', restrictAttributeOperation( editor ), { priority: 'high' } );
 
 		const inputCommand = this.editor.commands.get( 'input' );
 
@@ -172,8 +179,6 @@ export default class RestrictedEditingModeEditing extends Plugin {
 		if ( inputCommand ) {
 			this.listenTo( inputCommand, 'execute', restrictInputRangeOption( editor ), { priority: 'high' } );
 		}
-
-		setupExceptionHighlighting( editor );
 	}
 
 	/**

--- a/src/restrictededitingmodeediting.js
+++ b/src/restrictededitingmodeediting.js
@@ -320,7 +320,7 @@ function restrictDeleteContent( editor ) {
 
 // Ensures that remove attribute operation is executed on proper range.
 //
-// The restriction is enforced by trimming range of an AttributeOperation:
+// The restriction is enforced by trimming range of an AttributeOperation.
 function restrictAttributeOperation( editor ) {
 	return ( evt, args ) => {
 		const [ operation ] = args;

--- a/src/restrictededitingmodeediting.js
+++ b/src/restrictededitingmodeediting.js
@@ -162,6 +162,24 @@ export default class RestrictedEditingModeEditing extends Plugin {
 		doc.registerPostFixer( extendMarkerOnTypingPostFixer( editor ) );
 		doc.registerPostFixer( resurrectCollapsedMarkerPostFixer( editor ) );
 
+		editor.model.on( 'deleteContent', ( evt, args ) => {
+			// console.log( 'bofore:deleteContent', evt.stop() );
+			const [ selection, ] = args;
+
+			const marker = getMarkerAtPosition( editor, selection.focus ) || getMarkerAtPosition( editor, selection.anchor );
+
+			if ( !marker ) {
+				evt.stop();
+				return;
+			}
+
+			const intersection = marker.getRange().getIntersection( selection.getFirstRange() );
+
+			const allowedToDelete = model.createSelection( intersection );
+
+			args.splice( 0, 1, allowedToDelete );
+		}, { priority: 'high' } );
+
 		setupExceptionHighlighting( editor );
 	}
 

--- a/src/restrictededitingmodeediting.js
+++ b/src/restrictededitingmodeediting.js
@@ -166,6 +166,11 @@ export default class RestrictedEditingModeEditing extends Plugin {
 		setupExceptionHighlighting( editor );
 	}
 
+	/**
+	 * Setups additional editing restrictions beyond command toggling.
+	 *
+	 * @private
+	 */
 	_setupRestrictions() {
 		const editor = this.editor;
 
@@ -177,7 +182,7 @@ export default class RestrictedEditingModeEditing extends Plugin {
 		// The restricted editing might be configured without input support - ie allow only bolding or removing text.
 		// This check is bit synthetic since only tests are used this way.
 		if ( inputCommand ) {
-			this.listenTo( inputCommand, 'execute', restrictInputRangeOption( editor ), { priority: 'high' } );
+			this.listenTo( inputCommand, 'execute', disallowInputExecForWrongRange( editor ), { priority: 'high' } );
 		}
 	}
 
@@ -358,7 +363,7 @@ function restrictAttributeOperation( editor ) {
 // Ensures that input command is executed with a range that is inside exception marker.
 //
 // This restriction is due to fact that using native spell check changes text outside exception marker.
-function restrictInputRangeOption( editor ) {
+function disallowInputExecForWrongRange( editor ) {
 	return ( evt, args ) => {
 		const [ options ] = args;
 		const { range } = options;

--- a/tests/manual/restrictedediting.html
+++ b/tests/manual/restrictedediting.html
@@ -7,6 +7,7 @@
 <div id="editor">
 	<h2>Heading 1</h2>
 	<p>Paragraph <span class="ck-restricted-editing-exception">it is editable</span></p>
+	<p>Exception on part of a word: <a href="ckeditor.com">coompi</a><span class="ck-restricted-editing-exception"><a href="ckeditor.com">ter</a> (fix spelling in Firefox).</span></p>
 	<p><strong>Bold</strong> <i>Italic</i> <a href="foo">Link</a></p>
 	<ul>
 		<li>UL List item 1</li>

--- a/tests/restrictededitingmodeediting.js
+++ b/tests/restrictededitingmodeediting.js
@@ -344,7 +344,7 @@ describe( 'RestrictedEditingModeEditing', () => {
 		} );
 	} );
 
-	describe( 'post-fixer', () => {
+	describe( 'enforcing restrictions on deleteContent', () => {
 		beforeEach( async () => {
 			editor = await VirtualTestEditor.create( { plugins: [ Paragraph, Typing, RestrictedEditingModeEditing ] } );
 			model = editor.model;

--- a/tests/restrictededitingmodeediting.js
+++ b/tests/restrictededitingmodeediting.js
@@ -418,6 +418,67 @@ describe( 'RestrictedEditingModeEditing', () => {
 		} );
 	} );
 
+	describe( 'enforcing restrictions on remove attribute operation', () => {
+		beforeEach( async () => {
+			editor = await VirtualTestEditor.create( { plugins: [ Paragraph, Typing, RestrictedEditingModeEditing ] } );
+			model = editor.model;
+
+			editor.model.schema.extend( '$text', { allowAttributes: [ 'link' ] } );
+		} );
+
+		afterEach( async () => {
+			await editor.destroy();
+		} );
+
+		it( 'should not allow to delete content outside restricted area', () => {
+			setModelData( model, '<paragraph><$text link="true">[]foo bar</$text> baz</paragraph>' );
+			const firstParagraph = model.document.getRoot().getChild( 0 );
+			addExceptionMarker( 4, 7, firstParagraph );
+
+			model.change( writer => {
+				writer.removeAttribute( 'link', writer.createRange(
+					writer.createPositionAt( firstParagraph, 0 ),
+					writer.createPositionAt( firstParagraph, 1 )
+				) );
+			} );
+
+			assertEqualMarkup( getModelData( model ), '<paragraph><$text link="true">[]foo bar</$text> baz</paragraph>' );
+		} );
+
+		it( 'should trim deleted content to a exception marker (end in marker)', () => {
+			setModelData( model, '<paragraph><$text link="true">[]foo bar</$text> baz</paragraph>' );
+			const firstParagraph = model.document.getRoot().getChild( 0 );
+			addExceptionMarker( 4, 7, firstParagraph );
+
+			model.change( writer => {
+				writer.removeAttribute( 'link', writer.createRange(
+					writer.createPositionAt( firstParagraph, 0 ),
+					writer.createPositionAt( firstParagraph, 7 )
+				) );
+			} );
+
+			assertEqualMarkup( getModelData( model ), '<paragraph><$text link="true">[]foo </$text>bar baz</paragraph>' );
+		} );
+
+		it( 'should trim deleted content to a exception marker (start in marker)', () => {
+			setModelData( model, '<paragraph><$text link="true">[]foo bar baz</$text></paragraph>' );
+			const firstParagraph = model.document.getRoot().getChild( 0 );
+			addExceptionMarker( 4, 7, firstParagraph );
+
+			model.change( writer => {
+				writer.removeAttribute( 'link', writer.createRange(
+					writer.createPositionAt( firstParagraph, 5 ),
+					writer.createPositionAt( firstParagraph, 8 )
+				) );
+			} );
+
+			assertEqualMarkup(
+				getModelData( model ),
+				'<paragraph><$text link="true">[]foo b</$text>ar<$text link="true"> baz</$text></paragraph>'
+			);
+		} );
+	} );
+
 	describe( 'clipboard', () => {
 		let model, viewDoc;
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Restricted editing boundaries should not be crossed by enabled commands. Closes ckeditor/ckeditor5#5840.

---

### Additional information

This PR fixes 3 things:
1. Deleting content using `model.deleteContent()` used by delete command with a "word" modifier (ctrl + del)
  Fixed by changing `selection` argument passed to `deleteContent` method (using decorator)
2. Removing attributes
  :warning:  controversial one: Fixed by changing `range` for `AttributeOperation` in `applyOperation` method decorator. Nicer would be decorator for some method (`writer.removeAttribute()`?) since `operation.range` is "readonly". Fastest to implement.
3. Inserting content using `model.insertContent()` which was triggered by native spell check (in Firefox)
  Fixed by a decorator for `InputCommand.execute()` that blocks `execute()` for ranges that crosses one exception marker.

Side note: this could be 3 separate PRs that addresses those 3 things separately.


