### PR TITLE
I/5840: Safe fixes to enforcing restricted editing restrictions

### DIFF
--- a/src/restrictededitingmode/converters.js
+++ b/src/restrictededitingmode/converters.js
@@ -103,9 +103,9 @@ export function extendMarkerOnTypingPostFixer( editor ) {
 		let changeApplied = false;
 
 		for ( const change of editor.model.document.differ.getChanges() ) {
-			if ( change.type == 'insert' && change.name == '$text' && change.length === 1 ) {
-				changeApplied = _tryExtendMarkerStart( editor, change.position, writer ) || changeApplied;
-				changeApplied = _tryExtendMarkedEnd( editor, change.position, writer ) || changeApplied;
+			if ( change.type == 'insert' && change.name == '$text' ) {
+				changeApplied = _tryExtendMarkerStart( editor, change.position, change.length, writer ) || changeApplied;
+				changeApplied = _tryExtendMarkedEnd( editor, change.position, change.length, writer ) || changeApplied;
 			}
 		}
 
@@ -159,13 +159,13 @@ export function upcastHighlightToMarker( config ) {
 	} );
 }
 
-// Extend marker if typing detected on marker's start position.
-function _tryExtendMarkerStart( editor, position, writer ) {
-	const markerAtStart = getMarkerAtPosition( editor, position.getShiftedBy( 1 ) );
+// Extend marker if change detected on marker's start position.
+function _tryExtendMarkerStart( editor, position, length, writer ) {
+	const markerAtStart = getMarkerAtPosition( editor, position.getShiftedBy( length ) );
 
-	if ( markerAtStart && markerAtStart.getStart().isEqual( position.getShiftedBy( 1 ) ) ) {
+	if ( markerAtStart && markerAtStart.getStart().isEqual( position.getShiftedBy( length ) ) ) {
 		writer.updateMarker( markerAtStart, {
-			range: writer.createRange( markerAtStart.getStart().getShiftedBy( -1 ), markerAtStart.getEnd() )
+			range: writer.createRange( markerAtStart.getStart().getShiftedBy( -length ), markerAtStart.getEnd() )
 		} );
 
 		return true;
@@ -174,13 +174,13 @@ function _tryExtendMarkerStart( editor, position, writer ) {
 	return false;
 }
 
-// Extend marker if typing detected on marker's end position.
-function _tryExtendMarkedEnd( editor, position, writer ) {
+// Extend marker if change detected on marker's end position.
+function _tryExtendMarkedEnd( editor, position, length, writer ) {
 	const markerAtEnd = getMarkerAtPosition( editor, position );
 
 	if ( markerAtEnd && markerAtEnd.getEnd().isEqual( position ) ) {
 		writer.updateMarker( markerAtEnd, {
-			range: writer.createRange( markerAtEnd.getStart(), markerAtEnd.getEnd().getShiftedBy( 1 ) )
+			range: writer.createRange( markerAtEnd.getStart(), markerAtEnd.getEnd().getShiftedBy( length ) )
 		} );
 
 		return true;

--- a/src/restrictededitingmodeediting.js
+++ b/src/restrictededitingmodeediting.js
@@ -76,6 +76,7 @@ export default class RestrictedEditingModeEditing extends Plugin {
 
 		this._setupConversion();
 		this._setupCommandsToggling();
+		this._setupRestrictions();
 
 		// Commands & keystrokes that allow navigation in the content.
 		editor.commands.add( 'goToPreviousRestrictedEditingException', new RestrictedEditingNavigationCommand( editor, 'backward' ) );
@@ -162,8 +163,14 @@ export default class RestrictedEditingModeEditing extends Plugin {
 		doc.registerPostFixer( extendMarkerOnTypingPostFixer( editor ) );
 		doc.registerPostFixer( resurrectCollapsedMarkerPostFixer( editor ) );
 
-		this.listenTo( model, 'deleteContent', restrictDeleteContent( editor ), { priority: 'high' } );
-		this.listenTo( model, 'applyOperation', restrictAttributeOperation( editor ), { priority: 'high' } );
+		setupExceptionHighlighting( editor );
+	}
+
+	_setupRestrictions() {
+		const editor = this.editor;
+
+		this.listenTo( editor.model, 'deleteContent', restrictDeleteContent( editor ), { priority: 'high' } );
+		this.listenTo( editor.model, 'applyOperation', restrictAttributeOperation( editor ), { priority: 'high' } );
 
 		const inputCommand = this.editor.commands.get( 'input' );
 
@@ -172,8 +179,6 @@ export default class RestrictedEditingModeEditing extends Plugin {
 		if ( inputCommand ) {
 			this.listenTo( inputCommand, 'execute', restrictInputRangeOption( editor ), { priority: 'high' } );
 		}
-
-		setupExceptionHighlighting( editor );
 	}
 
 	/**

--- a/src/restrictededitingmodeediting.js
+++ b/src/restrictededitingmodeediting.js
@@ -320,7 +320,7 @@ function restrictDeleteContent( editor ) {
 
 // Ensures that remove attribute operation is executed on proper range.
 //
-// The restriction is enforced by trimming range of an AttributeOperation:
+// The restriction is enforced by trimming range of an AttributeOperation.
 function restrictAttributeOperation( editor ) {
 	return ( evt, args ) => {
 		const [ operation ] = args;

--- a/src/restrictededitingmodeediting.js
+++ b/src/restrictededitingmodeediting.js
@@ -162,6 +162,24 @@ export default class RestrictedEditingModeEditing extends Plugin {
 		doc.registerPostFixer( extendMarkerOnTypingPostFixer( editor ) );
 		doc.registerPostFixer( resurrectCollapsedMarkerPostFixer( editor ) );
 
+		editor.model.on( 'deleteContent', ( evt, args ) => {
+			// console.log( 'bofore:deleteContent', evt.stop() );
+			const [ selection, ] = args;
+
+			const marker = getMarkerAtPosition( editor, selection.focus ) || getMarkerAtPosition( editor, selection.anchor );
+
+			if ( !marker ) {
+				evt.stop();
+				return;
+			}
+
+			const intersection = marker.getRange().getIntersection( selection.getFirstRange() );
+
+			const allowedToDelete = model.createSelection( intersection );
+
+			args.splice( 0, 1, allowedToDelete );
+		}, { priority: 'high' } );
+
 		setupExceptionHighlighting( editor );
 	}
 

--- a/src/restrictededitingmodeediting.js
+++ b/src/restrictededitingmodeediting.js
@@ -331,15 +331,14 @@ function restrictDeleteContent( editor ) {
 		// Shrink the selection to the range inside exception marker.
 		const allowedToDelete = marker.getRange().getIntersection( selection.getFirstRange() );
 
-		// Because the DeleteCommand uses the same selection to set selection after calling model.deleteContent() it is better to modify
-		// the argument selection. The only problem is when that when DocumentSelection is passed (or used internally) as it does allows
-		// to be modified.
-		// Instead we change the arguments passed to `deleteContent()` method when document selection was passed.
+		// Some features uses selection passed to model.deleteContent() to set the selection afterwards. For this we need to properly modify
+		// either the document selection using change block...
 		if ( selection.is( 'documentSelection' ) ) {
-			args[ 0 ] = editor.model.createSelection( allowedToDelete );
+			editor.model.change( writer => {
+				writer.setSelection( allowedToDelete );
+			} );
 		}
-		// We need to modify selection passed to deleteContent if it is an instance of selection because DeleteCommand uses passed
-		// selection to set selection afterwards. Since we modifying this here the selection set after the delete content will be invalid.
+		// ... or by modifying passed selection instance directly.
 		else {
 			selection.setTo( allowedToDelete );
 		}

--- a/src/restrictededitingmodeediting.js
+++ b/src/restrictededitingmodeediting.js
@@ -166,6 +166,11 @@ export default class RestrictedEditingModeEditing extends Plugin {
 		setupExceptionHighlighting( editor );
 	}
 
+	/**
+	 * Setups additional editing restrictions beyond command toggling.
+	 *
+	 * @private
+	 */
 	_setupRestrictions() {
 		const editor = this.editor;
 
@@ -177,7 +182,7 @@ export default class RestrictedEditingModeEditing extends Plugin {
 		// The restricted editing might be configured without input support - ie allow only bolding or removing text.
 		// This check is bit synthetic since only tests are used this way.
 		if ( inputCommand ) {
-			this.listenTo( inputCommand, 'execute', restrictInputRangeOption( editor ), { priority: 'high' } );
+			this.listenTo( inputCommand, 'execute', disallowInputExecForWrongRange( editor ), { priority: 'high' } );
 		}
 	}
 
@@ -358,7 +363,7 @@ function restrictAttributeOperation( editor ) {
 // Ensures that input command is executed with a range that is inside exception marker.
 //
 // This restriction is due to fact that using native spell check changes text outside exception marker.
-function restrictInputRangeOption( editor ) {
+function disallowInputExecForWrongRange( editor ) {
 	return ( evt, args ) => {
 		const [ options ] = args;
 		const { range } = options;

--- a/src/restrictededitingmodeediting.js
+++ b/src/restrictededitingmodeediting.js
@@ -328,10 +328,21 @@ function restrictDeleteContent( editor ) {
 			return;
 		}
 
+		// Shrink the selection to the range inside exception marker.
 		const allowedToDelete = marker.getRange().getIntersection( selection.getFirstRange() );
 
-		// Shrink the selection to the range inside exception marker.
-		selection.setTo( allowedToDelete );
+		// Because the DeleteCommand uses the same selection to set selection after calling model.deleteContent() it is better to modify
+		// the argument selection. The only problem is when that when DocumentSelection is passed (or used internally) as it does allows
+		// to be modified.
+		// Instead we change the arguments passed to `deleteContent()` method when document selection was passed.
+		if ( selection.is( 'documentSelection' ) ) {
+			args.splice( 0, 1, editor.model.createSelection( allowedToDelete ) );
+		}
+		// We need to modify selection passed to deleteContent if it is an instance of selection because DeleteCommand uses passed
+		// selection to set selection afterwards. Since we modifying this here the selection set after the delete content will be invalid.
+		else {
+			selection.setTo( allowedToDelete );
+		}
 	};
 }
 

--- a/src/restrictededitingmodeediting.js
+++ b/src/restrictededitingmodeediting.js
@@ -175,7 +175,6 @@ export default class RestrictedEditingModeEditing extends Plugin {
 		const editor = this.editor;
 
 		this.listenTo( editor.model, 'deleteContent', restrictDeleteContent( editor ), { priority: 'high' } );
-		this.listenTo( editor.model, 'applyOperation', restrictAttributeOperation( editor ), { priority: 'high' } );
 
 		const inputCommand = this.editor.commands.get( 'input' );
 
@@ -333,30 +332,6 @@ function restrictDeleteContent( editor ) {
 
 		// Shrink the selection to the range inside exception marker.
 		selection.setTo( allowedToDelete );
-	};
-}
-
-// Ensures that remove attribute operation is executed on proper range.
-//
-// The restriction is enforced by trimming range of an AttributeOperation.
-function restrictAttributeOperation( editor ) {
-	return ( evt, args ) => {
-		const [ operation ] = args;
-
-		if ( operation.type != 'removeAttribute' ) {
-			return;
-		}
-
-		const marker = getMarkerAtPosition( editor, operation.range.start ) || getMarkerAtPosition( editor, operation.range.end );
-
-		// Stop method execution if marker was not found at selection focus.
-		if ( !marker ) {
-			evt.stop();
-
-			return;
-		}
-
-		operation.range = operation.range.getIntersection( marker.getRange() );
 	};
 }
 

--- a/src/restrictededitingmodeediting.js
+++ b/src/restrictededitingmodeediting.js
@@ -336,7 +336,7 @@ function restrictDeleteContent( editor ) {
 		// to be modified.
 		// Instead we change the arguments passed to `deleteContent()` method when document selection was passed.
 		if ( selection.is( 'documentSelection' ) ) {
-			args.splice( 0, 1, editor.model.createSelection( allowedToDelete ) );
+			args[ 0 ] = editor.model.createSelection( allowedToDelete );
 		}
 		// We need to modify selection passed to deleteContent if it is an instance of selection because DeleteCommand uses passed
 		// selection to set selection afterwards. Since we modifying this here the selection set after the delete content will be invalid.

--- a/tests/manual/restrictedediting.html
+++ b/tests/manual/restrictedediting.html
@@ -7,6 +7,7 @@
 <div id="editor">
 	<h2>Heading 1</h2>
 	<p>Paragraph <span class="ck-restricted-editing-exception">it is editable</span></p>
+	<p>Exception on part of a word: <a href="ckeditor.com">coompi</a><span class="ck-restricted-editing-exception"><a href="ckeditor.com">ter</a> (fix spelling in Firefox).</span></p>
 	<p><strong>Bold</strong> <i>Italic</i> <a href="foo">Link</a></p>
 	<ul>
 		<li>UL List item 1</li>

--- a/tests/restrictededitingmodeediting.js
+++ b/tests/restrictededitingmodeediting.js
@@ -315,6 +315,64 @@ describe( 'RestrictedEditingModeEditing', () => {
 			expect( markerRange.isEqual( expectedRange ) ).to.be.true;
 		} );
 
+		it( 'should retain marker on non-typing change at the marker boundary (start)', () => {
+			setModelData( model, '<paragraph>foo bar[] baz</paragraph>' );
+			const firstParagraph = model.document.getRoot().getChild( 0 );
+			addExceptionMarker( 4, 7, firstParagraph );
+
+			model.change( writer => {
+				editor.execute( 'delete', {
+					selection: writer.createSelection( writer.createRange(
+						writer.createPositionAt( firstParagraph, 4 ),
+						writer.createPositionAt( firstParagraph, 6 )
+					) )
+				} );
+				editor.execute( 'input', {
+					text: 'XX',
+					range: writer.createRange( writer.createPositionAt( firstParagraph, 4 ) )
+				} );
+			} );
+
+			assertEqualMarkup( getModelData( model ), '<paragraph>foo XX[]r baz</paragraph>' );
+
+			const markerRange = editor.model.markers.get( 'restrictedEditingException:1' ).getRange();
+			const expectedRange = model.createRange(
+				model.createPositionAt( firstParagraph, 4 ),
+				model.createPositionAt( firstParagraph, 7 )
+			);
+
+			expect( markerRange.isEqual( expectedRange ) ).to.be.true;
+		} );
+
+		it( 'should retain marker on non-typing change at marker boundary (end)', () => {
+			setModelData( model, '<paragraph>foo bar[] baz</paragraph>' );
+			const firstParagraph = model.document.getRoot().getChild( 0 );
+			addExceptionMarker( 4, 7, firstParagraph );
+
+			model.change( writer => {
+				editor.execute( 'delete', {
+					selection: writer.createSelection( writer.createRange(
+						writer.createPositionAt( firstParagraph, 5 ),
+						writer.createPositionAt( firstParagraph, 7 )
+					) )
+				} );
+				editor.execute( 'input', {
+					text: 'XX',
+					range: writer.createRange( writer.createPositionAt( firstParagraph, 5 ) )
+				} );
+			} );
+
+			assertEqualMarkup( getModelData( model ), '<paragraph>foo bXX[] baz</paragraph>' );
+
+			const markerRange = editor.model.markers.get( 'restrictedEditingException:1' ).getRange();
+			const expectedRange = model.createRange(
+				model.createPositionAt( firstParagraph, 4 ),
+				model.createPositionAt( firstParagraph, 7 )
+			);
+
+			expect( markerRange.isEqual( expectedRange ) ).to.be.true;
+		} );
+
 		it( 'should not move collapsed marker to $graveyard', () => {
 			setModelData( model, '<paragraph>foo b[]ar baz</paragraph>' );
 			const firstParagraph = model.document.getRoot().getChild( 0 );
@@ -418,7 +476,7 @@ describe( 'RestrictedEditingModeEditing', () => {
 		} );
 
 		it( 'should work with document selection', () => {
-			setModelData( model, '<paragraph>foo [bar] baz</paragraph>' );
+			setModelData( model, '<paragraph>f[oo bar] baz</paragraph>' );
 			const firstParagraph = model.document.getRoot().getChild( 0 );
 
 			addExceptionMarker( 2, 'end', firstParagraph );
@@ -427,7 +485,7 @@ describe( 'RestrictedEditingModeEditing', () => {
 				model.deleteContent( model.document.selection );
 			} );
 
-			assertEqualMarkup( getModelData( model ), '<paragraph>foo [] baz</paragraph>' );
+			assertEqualMarkup( getModelData( model, { withoutSelection: true } ), '<paragraph>fo baz</paragraph>' );
 		} );
 	} );
 

--- a/tests/restrictededitingmodeediting.js
+++ b/tests/restrictededitingmodeediting.js
@@ -344,7 +344,7 @@ describe( 'RestrictedEditingModeEditing', () => {
 		} );
 	} );
 
-	describe( 'post-fixer', () => {
+	describe( 'enforcing restrictions on deleteContent', () => {
 		beforeEach( async () => {
 			editor = await VirtualTestEditor.create( { plugins: [ Paragraph, Typing, RestrictedEditingModeEditing ] } );
 			model = editor.model;

--- a/tests/restrictededitingmodeediting.js
+++ b/tests/restrictededitingmodeediting.js
@@ -418,67 +418,6 @@ describe( 'RestrictedEditingModeEditing', () => {
 		} );
 	} );
 
-	describe( 'enforcing restrictions on remove attribute operation', () => {
-		beforeEach( async () => {
-			editor = await VirtualTestEditor.create( { plugins: [ Paragraph, Typing, RestrictedEditingModeEditing ] } );
-			model = editor.model;
-
-			editor.model.schema.extend( '$text', { allowAttributes: [ 'link' ] } );
-		} );
-
-		afterEach( async () => {
-			await editor.destroy();
-		} );
-
-		it( 'should not allow to delete content outside restricted area', () => {
-			setModelData( model, '<paragraph><$text link="true">[]foo bar</$text> baz</paragraph>' );
-			const firstParagraph = model.document.getRoot().getChild( 0 );
-			addExceptionMarker( 4, 7, firstParagraph );
-
-			model.change( writer => {
-				writer.removeAttribute( 'link', writer.createRange(
-					writer.createPositionAt( firstParagraph, 0 ),
-					writer.createPositionAt( firstParagraph, 1 )
-				) );
-			} );
-
-			assertEqualMarkup( getModelData( model ), '<paragraph><$text link="true">[]foo bar</$text> baz</paragraph>' );
-		} );
-
-		it( 'should trim deleted content to a exception marker (end in marker)', () => {
-			setModelData( model, '<paragraph><$text link="true">[]foo bar</$text> baz</paragraph>' );
-			const firstParagraph = model.document.getRoot().getChild( 0 );
-			addExceptionMarker( 4, 7, firstParagraph );
-
-			model.change( writer => {
-				writer.removeAttribute( 'link', writer.createRange(
-					writer.createPositionAt( firstParagraph, 0 ),
-					writer.createPositionAt( firstParagraph, 7 )
-				) );
-			} );
-
-			assertEqualMarkup( getModelData( model ), '<paragraph><$text link="true">[]foo </$text>bar baz</paragraph>' );
-		} );
-
-		it( 'should trim deleted content to a exception marker (start in marker)', () => {
-			setModelData( model, '<paragraph><$text link="true">[]foo bar baz</$text></paragraph>' );
-			const firstParagraph = model.document.getRoot().getChild( 0 );
-			addExceptionMarker( 4, 7, firstParagraph );
-
-			model.change( writer => {
-				writer.removeAttribute( 'link', writer.createRange(
-					writer.createPositionAt( firstParagraph, 5 ),
-					writer.createPositionAt( firstParagraph, 8 )
-				) );
-			} );
-
-			assertEqualMarkup(
-				getModelData( model ),
-				'<paragraph><$text link="true">[]foo b</$text>ar<$text link="true"> baz</$text></paragraph>'
-			);
-		} );
-	} );
-
 	describe( 'enforcing restrictions on input command', () => {
 		let firstParagraph;
 

--- a/tests/restrictededitingmodeediting.js
+++ b/tests/restrictededitingmodeediting.js
@@ -416,6 +416,19 @@ describe( 'RestrictedEditingModeEditing', () => {
 
 			assertEqualMarkup( getModelData( model ), '<paragraph>foo[] bar baz</paragraph>' );
 		} );
+
+		it( 'should work with document selection', () => {
+			setModelData( model, '<paragraph>foo [bar] baz</paragraph>' );
+			const firstParagraph = model.document.getRoot().getChild( 0 );
+
+			addExceptionMarker( 2, 'end', firstParagraph );
+
+			model.change( () => {
+				model.deleteContent( model.document.selection );
+			} );
+
+			assertEqualMarkup( getModelData( model ), '<paragraph>foo [] baz</paragraph>' );
+		} );
 	} );
 
 	describe( 'enforcing restrictions on input command', () => {

--- a/tests/restrictededitingmodeediting.js
+++ b/tests/restrictededitingmodeediting.js
@@ -418,6 +418,67 @@ describe( 'RestrictedEditingModeEditing', () => {
 		} );
 	} );
 
+	describe( 'enforcing restrictions on remove attribute operation', () => {
+		beforeEach( async () => {
+			editor = await VirtualTestEditor.create( { plugins: [ Paragraph, Typing, RestrictedEditingModeEditing ] } );
+			model = editor.model;
+
+			editor.model.schema.extend( '$text', { allowAttributes: [ 'link' ] } );
+		} );
+
+		afterEach( async () => {
+			await editor.destroy();
+		} );
+
+		it( 'should not allow to delete content outside restricted area', () => {
+			setModelData( model, '<paragraph><$text link="true">[]foo bar</$text> baz</paragraph>' );
+			const firstParagraph = model.document.getRoot().getChild( 0 );
+			addExceptionMarker( 4, 7, firstParagraph );
+
+			model.change( writer => {
+				writer.removeAttribute( 'link', writer.createRange(
+					writer.createPositionAt( firstParagraph, 0 ),
+					writer.createPositionAt( firstParagraph, 1 )
+				) );
+			} );
+
+			assertEqualMarkup( getModelData( model ), '<paragraph><$text link="true">[]foo bar</$text> baz</paragraph>' );
+		} );
+
+		it( 'should trim deleted content to a exception marker (end in marker)', () => {
+			setModelData( model, '<paragraph><$text link="true">[]foo bar</$text> baz</paragraph>' );
+			const firstParagraph = model.document.getRoot().getChild( 0 );
+			addExceptionMarker( 4, 7, firstParagraph );
+
+			model.change( writer => {
+				writer.removeAttribute( 'link', writer.createRange(
+					writer.createPositionAt( firstParagraph, 0 ),
+					writer.createPositionAt( firstParagraph, 7 )
+				) );
+			} );
+
+			assertEqualMarkup( getModelData( model ), '<paragraph><$text link="true">[]foo </$text>bar baz</paragraph>' );
+		} );
+
+		it( 'should trim deleted content to a exception marker (start in marker)', () => {
+			setModelData( model, '<paragraph><$text link="true">[]foo bar baz</$text></paragraph>' );
+			const firstParagraph = model.document.getRoot().getChild( 0 );
+			addExceptionMarker( 4, 7, firstParagraph );
+
+			model.change( writer => {
+				writer.removeAttribute( 'link', writer.createRange(
+					writer.createPositionAt( firstParagraph, 5 ),
+					writer.createPositionAt( firstParagraph, 8 )
+				) );
+			} );
+
+			assertEqualMarkup(
+				getModelData( model ),
+				'<paragraph><$text link="true">[]foo b</$text>ar<$text link="true"> baz</$text></paragraph>'
+			);
+		} );
+	} );
+
 	describe( 'clipboard', () => {
 		let model, viewDoc;
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Restricted editing boundaries should not be crossed by delete content and input command. Closes ckeditor/ckeditor5#5840.

---

### Additional information

* Safe subset of changes from the https://github.com/ckeditor/ckeditor5-restricted-editing/pull/5:
1. Deleting content using `model.deleteContent()` used by delete command with a "word" modifier (ctrl + del)
  Fixed by changing `selection` argument passed to `deleteContent` method (using decorator)
2. Inserting content using `model.insertContent()` which was triggered by native spell check (in Firefox)
  Fixed by a decorator for `InputCommand.execute()` that blocks `execute()` for ranges that crosses one exception marker.

