### PR TITLE
Revert "Remove attribute restriction enforcing."

### DIFF
--- a/src/restrictededitingmodeediting.js
+++ b/src/restrictededitingmodeediting.js
@@ -175,7 +175,6 @@ export default class RestrictedEditingModeEditing extends Plugin {
 		const editor = this.editor;
 
 		this.listenTo( editor.model, 'deleteContent', restrictDeleteContent( editor ), { priority: 'high' } );
-		this.listenTo( editor.model, 'applyOperation', restrictAttributeOperation( editor ), { priority: 'high' } );
 
 		const inputCommand = this.editor.commands.get( 'input' );
 
@@ -333,30 +332,6 @@ function restrictDeleteContent( editor ) {
 
 		// Shrink the selection to the range inside exception marker.
 		selection.setTo( allowedToDelete );
-	};
-}
-
-// Ensures that remove attribute operation is executed on proper range.
-//
-// The restriction is enforced by trimming range of an AttributeOperation.
-function restrictAttributeOperation( editor ) {
-	return ( evt, args ) => {
-		const [ operation ] = args;
-
-		if ( operation.type != 'removeAttribute' ) {
-			return;
-		}
-
-		const marker = getMarkerAtPosition( editor, operation.range.start ) || getMarkerAtPosition( editor, operation.range.end );
-
-		// Stop method execution if marker was not found at selection focus.
-		if ( !marker ) {
-			evt.stop();
-
-			return;
-		}
-
-		operation.range = operation.range.getIntersection( marker.getRange() );
 	};
 }
 

--- a/src/restrictededitingmodeediting.js
+++ b/src/restrictededitingmodeediting.js
@@ -175,6 +175,7 @@ export default class RestrictedEditingModeEditing extends Plugin {
 		const editor = this.editor;
 
 		this.listenTo( editor.model, 'deleteContent', restrictDeleteContent( editor ), { priority: 'high' } );
+		this.listenTo( editor.model, 'applyOperation', restrictAttributeOperation( editor ), { priority: 'high' } );
 
 		const inputCommand = this.editor.commands.get( 'input' );
 
@@ -332,6 +333,30 @@ function restrictDeleteContent( editor ) {
 
 		// Shrink the selection to the range inside exception marker.
 		selection.setTo( allowedToDelete );
+	};
+}
+
+// Ensures that remove attribute operation is executed on proper range.
+//
+// The restriction is enforced by trimming range of an AttributeOperation.
+function restrictAttributeOperation( editor ) {
+	return ( evt, args ) => {
+		const [ operation ] = args;
+
+		if ( operation.type != 'removeAttribute' ) {
+			return;
+		}
+
+		const marker = getMarkerAtPosition( editor, operation.range.start ) || getMarkerAtPosition( editor, operation.range.end );
+
+		// Stop method execution if marker was not found at selection focus.
+		if ( !marker ) {
+			evt.stop();
+
+			return;
+		}
+
+		operation.range = operation.range.getIntersection( marker.getRange() );
 	};
 }
 

--- a/tests/restrictededitingmodeediting.js
+++ b/tests/restrictededitingmodeediting.js
@@ -418,67 +418,6 @@ describe( 'RestrictedEditingModeEditing', () => {
 		} );
 	} );
 
-	describe( 'enforcing restrictions on remove attribute operation', () => {
-		beforeEach( async () => {
-			editor = await VirtualTestEditor.create( { plugins: [ Paragraph, Typing, RestrictedEditingModeEditing ] } );
-			model = editor.model;
-
-			editor.model.schema.extend( '$text', { allowAttributes: [ 'link' ] } );
-		} );
-
-		afterEach( async () => {
-			await editor.destroy();
-		} );
-
-		it( 'should not allow to delete content outside restricted area', () => {
-			setModelData( model, '<paragraph><$text link="true">[]foo bar</$text> baz</paragraph>' );
-			const firstParagraph = model.document.getRoot().getChild( 0 );
-			addExceptionMarker( 4, 7, firstParagraph );
-
-			model.change( writer => {
-				writer.removeAttribute( 'link', writer.createRange(
-					writer.createPositionAt( firstParagraph, 0 ),
-					writer.createPositionAt( firstParagraph, 1 )
-				) );
-			} );
-
-			assertEqualMarkup( getModelData( model ), '<paragraph><$text link="true">[]foo bar</$text> baz</paragraph>' );
-		} );
-
-		it( 'should trim deleted content to a exception marker (end in marker)', () => {
-			setModelData( model, '<paragraph><$text link="true">[]foo bar</$text> baz</paragraph>' );
-			const firstParagraph = model.document.getRoot().getChild( 0 );
-			addExceptionMarker( 4, 7, firstParagraph );
-
-			model.change( writer => {
-				writer.removeAttribute( 'link', writer.createRange(
-					writer.createPositionAt( firstParagraph, 0 ),
-					writer.createPositionAt( firstParagraph, 7 )
-				) );
-			} );
-
-			assertEqualMarkup( getModelData( model ), '<paragraph><$text link="true">[]foo </$text>bar baz</paragraph>' );
-		} );
-
-		it( 'should trim deleted content to a exception marker (start in marker)', () => {
-			setModelData( model, '<paragraph><$text link="true">[]foo bar baz</$text></paragraph>' );
-			const firstParagraph = model.document.getRoot().getChild( 0 );
-			addExceptionMarker( 4, 7, firstParagraph );
-
-			model.change( writer => {
-				writer.removeAttribute( 'link', writer.createRange(
-					writer.createPositionAt( firstParagraph, 5 ),
-					writer.createPositionAt( firstParagraph, 8 )
-				) );
-			} );
-
-			assertEqualMarkup(
-				getModelData( model ),
-				'<paragraph><$text link="true">[]foo b</$text>ar<$text link="true"> baz</$text></paragraph>'
-			);
-		} );
-	} );
-
 	describe( 'enforcing restrictions on input command', () => {
 		let firstParagraph;
 

--- a/tests/restrictededitingmodeediting.js
+++ b/tests/restrictededitingmodeediting.js
@@ -418,6 +418,67 @@ describe( 'RestrictedEditingModeEditing', () => {
 		} );
 	} );
 
+	describe( 'enforcing restrictions on remove attribute operation', () => {
+		beforeEach( async () => {
+			editor = await VirtualTestEditor.create( { plugins: [ Paragraph, Typing, RestrictedEditingModeEditing ] } );
+			model = editor.model;
+
+			editor.model.schema.extend( '$text', { allowAttributes: [ 'link' ] } );
+		} );
+
+		afterEach( async () => {
+			await editor.destroy();
+		} );
+
+		it( 'should not allow to delete content outside restricted area', () => {
+			setModelData( model, '<paragraph><$text link="true">[]foo bar</$text> baz</paragraph>' );
+			const firstParagraph = model.document.getRoot().getChild( 0 );
+			addExceptionMarker( 4, 7, firstParagraph );
+
+			model.change( writer => {
+				writer.removeAttribute( 'link', writer.createRange(
+					writer.createPositionAt( firstParagraph, 0 ),
+					writer.createPositionAt( firstParagraph, 1 )
+				) );
+			} );
+
+			assertEqualMarkup( getModelData( model ), '<paragraph><$text link="true">[]foo bar</$text> baz</paragraph>' );
+		} );
+
+		it( 'should trim deleted content to a exception marker (end in marker)', () => {
+			setModelData( model, '<paragraph><$text link="true">[]foo bar</$text> baz</paragraph>' );
+			const firstParagraph = model.document.getRoot().getChild( 0 );
+			addExceptionMarker( 4, 7, firstParagraph );
+
+			model.change( writer => {
+				writer.removeAttribute( 'link', writer.createRange(
+					writer.createPositionAt( firstParagraph, 0 ),
+					writer.createPositionAt( firstParagraph, 7 )
+				) );
+			} );
+
+			assertEqualMarkup( getModelData( model ), '<paragraph><$text link="true">[]foo </$text>bar baz</paragraph>' );
+		} );
+
+		it( 'should trim deleted content to a exception marker (start in marker)', () => {
+			setModelData( model, '<paragraph><$text link="true">[]foo bar baz</$text></paragraph>' );
+			const firstParagraph = model.document.getRoot().getChild( 0 );
+			addExceptionMarker( 4, 7, firstParagraph );
+
+			model.change( writer => {
+				writer.removeAttribute( 'link', writer.createRange(
+					writer.createPositionAt( firstParagraph, 5 ),
+					writer.createPositionAt( firstParagraph, 8 )
+				) );
+			} );
+
+			assertEqualMarkup(
+				getModelData( model ),
+				'<paragraph><$text link="true">[]foo b</$text>ar<$text link="true"> baz</$text></paragraph>'
+			);
+		} );
+	} );
+
 	describe( 'enforcing restrictions on input command', () => {
 		let firstParagraph;
 

--- a/tests/restrictededitingmodeediting.js
+++ b/tests/restrictededitingmodeediting.js
@@ -445,7 +445,7 @@ describe( 'RestrictedEditingModeEditing', () => {
 			assertEqualMarkup( getModelData( model ), '<paragraph><$text link="true">[]foo bar</$text> baz</paragraph>' );
 		} );
 
-		it( 'should trim deleted content to a exception marker (end in marker)', () => {
+		it( 'should trim deleted content to an exception marker (end in marker)', () => {
 			setModelData( model, '<paragraph><$text link="true">[]foo bar</$text> baz</paragraph>' );
 			const firstParagraph = model.document.getRoot().getChild( 0 );
 			addExceptionMarker( 4, 7, firstParagraph );
@@ -460,7 +460,7 @@ describe( 'RestrictedEditingModeEditing', () => {
 			assertEqualMarkup( getModelData( model ), '<paragraph><$text link="true">[]foo </$text>bar baz</paragraph>' );
 		} );
 
-		it( 'should trim deleted content to a exception marker (start in marker)', () => {
+		it( 'should trim deleted content to an exception marker (start in marker)', () => {
 			setModelData( model, '<paragraph><$text link="true">[]foo bar baz</$text></paragraph>' );
 			const firstParagraph = model.document.getRoot().getChild( 0 );
 			addExceptionMarker( 4, 7, firstParagraph );
@@ -476,6 +476,49 @@ describe( 'RestrictedEditingModeEditing', () => {
 				getModelData( model ),
 				'<paragraph><$text link="true">[]foo b</$text>ar<$text link="true"> baz</$text></paragraph>'
 			);
+		} );
+
+		it( 'should trim deleted content to an exception marker (start and ends outside a marker)', () => {
+			setModelData( model, '<paragraph><$text link="true">[]foo bar baz</$text></paragraph>' );
+			const firstParagraph = model.document.getRoot().getChild( 0 );
+			addExceptionMarker( 4, 7, firstParagraph );
+
+			model.change( writer => {
+				writer.removeAttribute( 'link', writer.createRange(
+					writer.createPositionAt( firstParagraph, 0 ),
+					writer.createPositionAt( firstParagraph, 'end' )
+				) );
+			} );
+
+			assertEqualMarkup(
+				getModelData( model ),
+				'<paragraph><$text link="true">[]foo </$text>bar<$text link="true"> baz</$text></paragraph>'
+			);
+		} );
+
+		it( 'should trim deleted content to an exception marker (start and ends outside a marker - intersecting many markers)', () => {
+			setModelData( model, '<paragraph><$text link="true">[]foo bar baz</$text></paragraph>' );
+			const firstParagraph = model.document.getRoot().getChild( 0 );
+			addExceptionMarker( 1, 2, firstParagraph );
+			addExceptionMarker( 3, 4, firstParagraph, 2 );
+			addExceptionMarker( 5, 6, firstParagraph, 3 );
+
+			model.change( writer => {
+				writer.removeAttribute( 'link', writer.createRange(
+					writer.createPositionAt( firstParagraph, 0 ),
+					writer.createPositionAt( firstParagraph, 'end' )
+				) );
+			} );
+
+			assertEqualMarkup( getModelData( model ), '<paragraph>' +
+					'<$text link="true">[]f</$text>' +
+					'o' + // First marker.
+					'<$text link="true">o</$text>' +
+					' ' + // Second marker.
+					'<$text link="true">b</$text>' +
+					'a' + // Third marker.
+					'<$text link="true">r baz</$text>' +
+				'</paragraph>' );
 		} );
 	} );
 

--- a/tests/restrictededitingmodeediting.js
+++ b/tests/restrictededitingmodeediting.js
@@ -430,7 +430,7 @@ describe( 'RestrictedEditingModeEditing', () => {
 			await editor.destroy();
 		} );
 
-		it( 'should not allow to delete content outside restricted area', () => {
+		it( 'should not allow to change attributes outside restricted area', () => {
 			setModelData( model, '<paragraph><$text link="true">[]foo bar</$text> baz</paragraph>' );
 			const firstParagraph = model.document.getRoot().getChild( 0 );
 			addExceptionMarker( 4, 7, firstParagraph );
@@ -445,7 +445,7 @@ describe( 'RestrictedEditingModeEditing', () => {
 			assertEqualMarkup( getModelData( model ), '<paragraph><$text link="true">[]foo bar</$text> baz</paragraph>' );
 		} );
 
-		it( 'should trim deleted content to an exception marker (end in marker)', () => {
+		it( 'should keep attributes outside an exception marker (end in marker)', () => {
 			setModelData( model, '<paragraph><$text link="true">[]foo bar</$text> baz</paragraph>' );
 			const firstParagraph = model.document.getRoot().getChild( 0 );
 			addExceptionMarker( 4, 7, firstParagraph );
@@ -460,7 +460,7 @@ describe( 'RestrictedEditingModeEditing', () => {
 			assertEqualMarkup( getModelData( model ), '<paragraph><$text link="true">[]foo </$text>bar baz</paragraph>' );
 		} );
 
-		it( 'should trim deleted content to an exception marker (start in marker)', () => {
+		it( 'should should keep attributes outside an exception marker (start in marker)', () => {
 			setModelData( model, '<paragraph><$text link="true">[]foo bar baz</$text></paragraph>' );
 			const firstParagraph = model.document.getRoot().getChild( 0 );
 			addExceptionMarker( 4, 7, firstParagraph );
@@ -478,7 +478,7 @@ describe( 'RestrictedEditingModeEditing', () => {
 			);
 		} );
 
-		it( 'should trim deleted content to an exception marker (start and ends outside a marker)', () => {
+		it( 'should should keep attributes outside an exception marker (start and ends outside a marker)', () => {
 			setModelData( model, '<paragraph><$text link="true">[]foo bar baz</$text></paragraph>' );
 			const firstParagraph = model.document.getRoot().getChild( 0 );
 			addExceptionMarker( 4, 7, firstParagraph );
@@ -496,7 +496,7 @@ describe( 'RestrictedEditingModeEditing', () => {
 			);
 		} );
 
-		it( 'should trim deleted content to an exception marker (start and ends outside a marker - intersecting many markers)', () => {
+		it( 'should should keep attribute outside multiple exception markers', () => {
 			setModelData( model, '<paragraph><$text link="true">[]foo bar baz</$text></paragraph>' );
 			const firstParagraph = model.document.getRoot().getChild( 0 );
 			addExceptionMarker( 1, 2, firstParagraph );
@@ -518,6 +518,35 @@ describe( 'RestrictedEditingModeEditing', () => {
 					'<$text link="true">b</$text>' +
 					'a' + // Third marker.
 					'<$text link="true">r baz</$text>' +
+				'</paragraph>' );
+		} );
+
+		it( 'should should keep multiple attributes outside multiple exception markers', () => {
+			setModelData( model, '<paragraph><$text bold="true" link="true">[]foo bar baz</$text></paragraph>' );
+			const firstParagraph = model.document.getRoot().getChild( 0 );
+			addExceptionMarker( 1, 2, firstParagraph );
+			addExceptionMarker( 3, 4, firstParagraph, 2 );
+			addExceptionMarker( 5, 6, firstParagraph, 3 );
+
+			model.change( writer => {
+				writer.removeAttribute( 'link', writer.createRange(
+					writer.createPositionAt( firstParagraph, 0 ),
+					writer.createPositionAt( firstParagraph, 'end' )
+				) );
+				writer.removeAttribute( 'bold', writer.createRange(
+					writer.createPositionAt( firstParagraph, 0 ),
+					writer.createPositionAt( firstParagraph, 'end' )
+				) );
+			} );
+
+			assertEqualMarkup( getModelData( model ), '<paragraph>' +
+				'<$text bold="true" link="true">[]f</$text>' +
+				'o' + // First marker.
+				'<$text bold="true" link="true">o</$text>' +
+				' ' + // Second marker.
+				'<$text bold="true" link="true">b</$text>' +
+				'a' + // Third marker.
+				'<$text bold="true" link="true">r baz</$text>' +
 				'</paragraph>' );
 		} );
 	} );


### PR DESCRIPTION
This reverts commit 37e717ce

### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Restricted editing boundaries should not be crossed by attribute operations. See ckeditor/ckeditor5#5840.

---

### Additional information

* Follow-up to the https://github.com/ckeditor/ckeditor5-restricted-editing/pull/7

1.  :warning:  controversial one: Fixed by changing `range` for `AttributeOperation` in `applyOperation` method decorator. Nicer would be decorator for some method (`writer.removeAttribute()`?) since `operation.range` is "readonly". Fastest to implement.

---

It is a draft because it requires the previous one to be merged before and then this to be merged to `master` not the `i/5840-safe`.