### PR TITLE
I/5829: Add additional classes to editable to differentiate styling for each mode

### DIFF
--- a/src/restrictededitingmodeediting.js
+++ b/src/restrictededitingmodeediting.js
@@ -93,10 +93,9 @@ export default class RestrictedEditingModeEditing extends Plugin {
 			}
 		}, { priority: 'highest' } );
 
-		// Set unique class to every $root element for additional styling in restricted editing
 		editor.editing.view.change( writer => {
 			for ( const root of editor.editing.view.document.roots ) {
-				writer.addClass( 'ck-restricted-editing', root );
+				writer.addClass( 'ck-restricted-editing_mode_restricted', root );
 			}
 		} );
 	}

--- a/src/restrictededitingmodeediting.js
+++ b/src/restrictededitingmodeediting.js
@@ -92,6 +92,13 @@ export default class RestrictedEditingModeEditing extends Plugin {
 				evt.stop();
 			}
 		}, { priority: 'highest' } );
+
+		// Set unique class to every $root element for additional styling in restricted editing
+		editor.editing.view.change( writer => {
+			for ( const root of editor.editing.view.document.roots ) {
+				writer.addClass( 'ck-restricted-editing', root );
+			}
+		} );
 	}
 
 	/**

--- a/src/standardeditingmodeediting.js
+++ b/src/standardeditingmodeediting.js
@@ -54,5 +54,12 @@ export default class StandardEditingModeEditing extends Plugin {
 		} );
 
 		editor.commands.add( 'restrictedEditingException', new RestrictedEditingExceptionCommand( editor ) );
+
+		// Set unique class to every $root element for additional styling in standard editing
+		editor.editing.view.change( writer => {
+			for ( const root of editor.editing.view.document.roots ) {
+				writer.addClass( 'ck-standard-editing', root );
+			}
+		} );
 	}
 }

--- a/src/standardeditingmodeediting.js
+++ b/src/standardeditingmodeediting.js
@@ -55,10 +55,9 @@ export default class StandardEditingModeEditing extends Plugin {
 
 		editor.commands.add( 'restrictedEditingException', new RestrictedEditingExceptionCommand( editor ) );
 
-		// Set unique class to every $root element for additional styling in standard editing
 		editor.editing.view.change( writer => {
 			for ( const root of editor.editing.view.document.roots ) {
-				writer.addClass( 'ck-standard-editing', root );
+				writer.addClass( 'ck-restricted-editing_mode_standard', root );
 			}
 		} );
 	}

--- a/tests/restrictededitingmodeediting.js
+++ b/tests/restrictededitingmodeediting.js
@@ -40,6 +40,12 @@ describe( 'RestrictedEditingModeEditing', () => {
 			expect( editor.plugins.get( RestrictedEditingModeEditing ) ).to.be.instanceOf( RestrictedEditingModeEditing );
 		} );
 
+		it( 'should have "ck-restricted-editing_mode_restricted" class', () => {
+			for ( const root of editor.editing.view.document.roots ) {
+				expect( root.hasClass( 'ck-restricted-editing_mode_restricted' ) ).to.be.true;
+			}
+		} );
+
 		it( 'adds a "goToPreviousRestrictedEditingException" command', () => {
 			expect( editor.commands.get( 'goToPreviousRestrictedEditingException' ) )
 				.to.be.instanceOf( RestrictedEditingModeNavigationCommand );

--- a/tests/standardeditingmodeediting.js
+++ b/tests/standardeditingmodeediting.js
@@ -35,6 +35,12 @@ describe( 'StandardEditingModeEditing', () => {
 		expect( editor.plugins.get( 'StandardEditingModeEditing' ) ).to.be.instanceOf( StandardEditingModeEditing );
 	} );
 
+	it( 'should have "ck-restricted-editing_mode_standard" class', () => {
+		for ( const root of editor.editing.view.document.roots ) {
+			expect( root.hasClass( 'ck-restricted-editing_mode_standard' ) ).to.be.true;
+		}
+	} );
+
 	it( 'should set proper schema rules', () => {
 		expect( model.schema.checkAttribute( [ '$root', '$text' ], 'restrictedEditingException' ) ).to.be.true;
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Add hover state for all exeptions and fix width for collapsed exception in restricted editing. Closes ckeditor/ckeditor5#5829.

---

### Additional information

- This PR has also a sub-pr: https://github.com/ckeditor/ckeditor5-theme-lark/pull/259
