### PR TITLE
I/6003: Ensure exception marker is flat

### DIFF
--- a/src/restrictededitingmodeediting.js
+++ b/src/restrictededitingmodeediting.js
@@ -374,6 +374,9 @@ function isRangeInsideSingleMarker( editor, range ) {
 }
 
 // Checks if new marker range is flat. Non-flat ranges might appear during upcast conversion in nested structures, ie tables.
+//
+// Note: This marker fixer only consider case which is possible to create using StandardEditing mode plugin.
+// Markers created by developer in the data might break in many other ways.
 function ensureNewMarkerIsFlat( editor ) {
 	const model = editor.model;
 

--- a/src/restrictededitingmodeediting.js
+++ b/src/restrictededitingmodeediting.js
@@ -162,20 +162,7 @@ export default class RestrictedEditingModeEditing extends Plugin {
 
 		doc.registerPostFixer( extendMarkerOnTypingPostFixer( editor ) );
 		doc.registerPostFixer( resurrectCollapsedMarkerPostFixer( editor ) );
-
-		// Naive post-fixer.
-		model.markers.on( 'update:restrictedEditingException', ( evt, marker, oldRange, newRange ) => {
-			if ( !newRange.isFlat ) {
-				model.change( writer => {
-					writer.updateMarker( marker, {
-						range: writer.createRange(
-							writer.createPositionAt( newRange.end.parent, 0 ),
-							newRange.end
-						)
-					} );
-				} );
-			}
-		} );
+		model.markers.on( 'update:restrictedEditingException', ensureNewMarkerIsFlat( editor ) );
 
 		setupExceptionHighlighting( editor );
 	}
@@ -384,4 +371,27 @@ function isRangeInsideSingleMarker( editor, range ) {
 	const markerAtEnd = getMarkerAtPosition( editor, range.end );
 
 	return markerAtStart && markerAtEnd && markerAtEnd === markerAtStart;
+}
+
+// Checks if new marker range is flat. Non-flat ranges might appear during upcast conversion in nested structures, ie tables.
+function ensureNewMarkerIsFlat( editor ) {
+	const model = editor.model;
+
+	return ( evt, marker, oldRange, newRange ) => {
+		if ( !oldRange && !newRange.isFlat ) {
+			model.change( writer => {
+				const start = newRange.start;
+				const end = newRange.end;
+
+				const startIsHigherInTree = start.path.length > end.path.length;
+
+				const fixedStart = startIsHigherInTree ? newRange.start : writer.createPositionAt( end.parent, 0 );
+				const fixedEnd = startIsHigherInTree ? writer.createPositionAt( start.parent, 'end' ) : newRange.end;
+
+				writer.updateMarker( marker, {
+					range: writer.createRange( fixedStart, fixedEnd )
+				} );
+			} );
+		}
+	};
 }

--- a/src/restrictededitingmodeediting.js
+++ b/src/restrictededitingmodeediting.js
@@ -163,6 +163,20 @@ export default class RestrictedEditingModeEditing extends Plugin {
 		doc.registerPostFixer( extendMarkerOnTypingPostFixer( editor ) );
 		doc.registerPostFixer( resurrectCollapsedMarkerPostFixer( editor ) );
 
+		// Naive post-fixer.
+		model.markers.on( 'update:restrictedEditingException', ( evt, marker, oldRange, newRange ) => {
+			if ( !newRange.isFlat ) {
+				model.change( writer => {
+					writer.updateMarker( marker, {
+						range: writer.createRange(
+							writer.createPositionAt( newRange.end.parent, 0 ),
+							newRange.end
+						)
+					} );
+				} );
+			}
+		} );
+
 		setupExceptionHighlighting( editor );
 	}
 

--- a/src/restrictededitingmodeediting.js
+++ b/src/restrictededitingmodeediting.js
@@ -383,6 +383,8 @@ function isRangeInsideSingleMarker( editor, range ) {
 //
 // Note: This marker fixer only consider case which is possible to create using StandardEditing mode plugin.
 // Markers created by developer in the data might break in many other ways.
+//
+// See #6003.
 function ensureNewMarkerIsFlat( editor ) {
 	const model = editor.model;
 

--- a/tests/manual/restrictedediting.html
+++ b/tests/manual/restrictedediting.html
@@ -5,28 +5,13 @@
 </p>
 
 <div id="editor">
-	<h2>Heading 1</h2>
-	<p>Paragraph <span class="restricted-editing-exception">it is editable</span></p>
-	<p>Exception on part of a word: <a href="ckeditor.com">coompi</a><span class="restricted-editing-exception"><a href="ckeditor.com">ter</a> (fix spelling in Firefox).</span></p>
-	<p><strong>Bold</strong> <i>Italic</i> <a href="foo">Link</a></p>
-	<ul>
-		<li>UL List item 1</li>
-		<li>UL List item 2</li>
-	</ul>
-	<ol>
-		<li><span class="restricted-editing-exception">OL List item 1</span></li>
-		<li>OL List item 2</li>
-	</ol>
-	<figure class="image image-style-side">
-		<img alt="bar" src="sample.jpg">
-		<figcaption>Caption</figcaption>
+	<figure class="table">
+		<table>
+			<tbody>
+				<tr>
+					<td><span class="restricted-editing-exception">foo bar</span></td>
+				</tr>
+			</tbody>
+		</table>
 	</figure>
-	<blockquote>
-		<p>Quote</p>
-		<ul>
-			<li>Quoted UL List item 1</li>
-			<li>Quoted UL List item <span class="restricted-editing-exception">2</span></li>
-		</ul>
-		<p>Quote</p>
-	</blockquote>
 </div>

--- a/tests/manual/restrictedediting.html
+++ b/tests/manual/restrictedediting.html
@@ -5,6 +5,10 @@
 </p>
 
 <div id="editor">
+	<h2>Heading 1</h2>
+	<p>Paragraph <span class="restricted-editing-exception">it is editable</span></p>
+	<p>Exception on part of a word: <a href="ckeditor.com">coompi</a><span class="restricted-editing-exception"><a href="ckeditor.com">ter</a> (fix spelling in Firefox).</span></p>
+	<p><strong>Bold</strong> <i>Italic</i> <a href="foo">Link</a></p>
 	<figure class="table">
 		<table>
 			<tbody>
@@ -14,4 +18,24 @@
 			</tbody>
 		</table>
 	</figure>
+	<ul>
+		<li>UL List item 1</li>
+		<li>UL List item 2</li>
+	</ul>
+	<ol>
+		<li><span class="restricted-editing-exception">OL List item 1</span></li>
+		<li>OL List item 2</li>
+	</ol>
+	<figure class="image image-style-side">
+		<img alt="bar" src="sample.jpg">
+		<figcaption>Caption</figcaption>
+	</figure>
+	<blockquote>
+		<p>Quote</p>
+		<ul>
+			<li>Quoted UL List item 1</li>
+			<li>Quoted UL List item <span class="restricted-editing-exception">2</span></li>
+		</ul>
+		<p>Quote</p>
+	</blockquote>
 </div>


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Fix non-flat exception markers. Closes ckeditor/ckeditor5#6003.

---

The problem was with non-flat range of the marker which happened after upcast conversion.

I've added a "post-fixer" that listens to new markers and fixes non-flat markers. It is rather an edge case and I didn't consider other cases like markers set on `<table>` or so which "standard editing mode" does not allow to create.
