### PR TITLE
i/5828: Remove entire exception when collapsed selection is inside text with restricted attribute

### DIFF
--- a/src/restrictededitingexceptioncommand.js
+++ b/src/restrictededitingexceptioncommand.js
@@ -43,10 +43,7 @@ export default class RestrictedEditingExceptionCommand extends Command {
 				// When selection is inside a restricted text
 				if ( selection.hasAttribute( 'restrictedEditingException' ) ) {
 					// Find the full resticted range
-					const isSameRestrictedException = value => {
-						return value.item.hasAttribute( 'restrictedEditingException' ) &&
-						value.item.getAttribute( 'restrictedEditingException' ) === this.value;
-					};
+					const isSameRestrictedException = value => value.item.getAttribute( 'restrictedEditingException' ) === this.value;
 
 					const restrictedEditingExceptionStart = position.getLastMatchingPosition( isSameRestrictedException,
 						{ direction: 'backward' } );

--- a/src/restrictededitingexceptioncommand.js
+++ b/src/restrictededitingexceptioncommand.js
@@ -40,7 +40,7 @@ export default class RestrictedEditingExceptionCommand extends Command {
 			if ( selection.isCollapsed ) {
 				const position = selection.getFirstPosition();
 
-				// When selection is inside restricted text
+				// When selection is inside a restricted text
 				if ( selection.hasAttribute( 'restrictedEditingException' ) ) {
 					// Find the full resticted range
 					const isSameRestrictedException = value => {
@@ -55,8 +55,12 @@ export default class RestrictedEditingExceptionCommand extends Command {
 					const restrictedEditingExceptionRange = writer.createRange( restrictedEditingExceptionStart,
 						restrictedEditingExceptionEnd );
 
-					writer.removeAttribute( 'restrictedEditingException', restrictedEditingExceptionRange );
 					writer.removeSelectionAttribute( 'restrictedEditingException' );
+
+					// Remove entire exception if the caret isn't at the end of a restricted text
+					if ( selection.anchor.textNode !== null ) {
+						writer.removeAttribute( 'restrictedEditingException', restrictedEditingExceptionRange );
+					}
 				} else if ( valueToSet ) {
 					// Set attribute on selection with unset attribute
 					writer.setSelectionAttribute( 'restrictedEditingException', valueToSet );

--- a/src/restrictededitingexceptioncommand.js
+++ b/src/restrictededitingexceptioncommand.js
@@ -38,29 +38,21 @@ export default class RestrictedEditingExceptionCommand extends Command {
 			const ranges = model.schema.getValidRanges( selection.getRanges(), 'restrictedEditingException' );
 
 			if ( selection.isCollapsed ) {
-				const position = selection.getFirstPosition();
-
-				// When selection is inside a restricted text
-				if ( selection.hasAttribute( 'restrictedEditingException' ) ) {
-					// Find the full resticted range
-					const isSameRestrictedException = value => value.item.getAttribute( 'restrictedEditingException' ) === this.value;
-
-					const restrictedEditingExceptionStart = position.getLastMatchingPosition( isSameRestrictedException,
+				if ( valueToSet ) {
+					writer.setSelectionAttribute( 'restrictedEditingException', valueToSet );
+				} else {
+					const isSameException = value => value.item.getAttribute( 'restrictedEditingException' ) === this.value;
+					const exceptionStart = selection.focus.getLastMatchingPosition( isSameException,
 						{ direction: 'backward' } );
-					const restrictedEditingExceptionEnd = position.getLastMatchingPosition( isSameRestrictedException );
-
-					const restrictedEditingExceptionRange = writer.createRange( restrictedEditingExceptionStart,
-						restrictedEditingExceptionEnd );
+					const exceptionEnd = selection.focus.getLastMatchingPosition( isSameException );
+					const focus = selection.focus;
 
 					writer.removeSelectionAttribute( 'restrictedEditingException' );
 
-					// Remove entire exception if the caret isn't at the end of a restricted text
-					if ( selection.anchor.textNode !== null ) {
-						writer.removeAttribute( 'restrictedEditingException', restrictedEditingExceptionRange );
+					if ( !( focus.isEqual( exceptionStart ) || focus.isEqual( exceptionEnd ) ) ) {
+						writer.removeAttribute( 'restrictedEditingException', writer.createRange( exceptionStart,
+							exceptionEnd ) );
 					}
-				} else if ( valueToSet ) {
-					// Set attribute on selection with unset attribute
-					writer.setSelectionAttribute( 'restrictedEditingException', valueToSet );
 				}
 			} else {
 				for ( const range of ranges ) {

--- a/src/restrictededitingexceptioncommand.js
+++ b/src/restrictededitingexceptioncommand.js
@@ -42,16 +42,14 @@ export default class RestrictedEditingExceptionCommand extends Command {
 					writer.setSelectionAttribute( 'restrictedEditingException', valueToSet );
 				} else {
 					const isSameException = value => value.item.getAttribute( 'restrictedEditingException' ) === this.value;
-					const exceptionStart = selection.focus.getLastMatchingPosition( isSameException,
-						{ direction: 'backward' } );
+					const exceptionStart = selection.focus.getLastMatchingPosition( isSameException, { direction: 'backward' } );
 					const exceptionEnd = selection.focus.getLastMatchingPosition( isSameException );
 					const focus = selection.focus;
 
 					writer.removeSelectionAttribute( 'restrictedEditingException' );
 
 					if ( !( focus.isEqual( exceptionStart ) || focus.isEqual( exceptionEnd ) ) ) {
-						writer.removeAttribute( 'restrictedEditingException', writer.createRange( exceptionStart,
-							exceptionEnd ) );
+						writer.removeAttribute( 'restrictedEditingException', writer.createRange( exceptionStart, exceptionEnd ) );
 					}
 				}
 			} else {

--- a/src/restrictededitingexceptioncommand.js
+++ b/src/restrictededitingexceptioncommand.js
@@ -38,10 +38,28 @@ export default class RestrictedEditingExceptionCommand extends Command {
 			const ranges = model.schema.getValidRanges( selection.getRanges(), 'restrictedEditingException' );
 
 			if ( selection.isCollapsed ) {
-				if ( valueToSet ) {
-					writer.setSelectionAttribute( 'restrictedEditingException', true );
-				} else {
+				const position = selection.getFirstPosition();
+
+				// When selection is inside restricted text
+				if ( selection.hasAttribute( 'restrictedEditingException' ) ) {
+					// Find the full resticted range
+					const isSameRestrictedException = value => {
+						return value.item.hasAttribute( 'restrictedEditingException' ) &&
+						value.item.getAttribute( 'restrictedEditingException' ) === this.value;
+					};
+
+					const restrictedEditingExceptionStart = position.getLastMatchingPosition( isSameRestrictedException,
+						{ direction: 'backward' } );
+					const restrictedEditingExceptionEnd = position.getLastMatchingPosition( isSameRestrictedException );
+
+					const restrictedEditingExceptionRange = writer.createRange( restrictedEditingExceptionStart,
+						restrictedEditingExceptionEnd );
+
+					writer.removeAttribute( 'restrictedEditingException', restrictedEditingExceptionRange );
 					writer.removeSelectionAttribute( 'restrictedEditingException' );
+				} else if ( valueToSet ) {
+					// Set attribute on selection with unset attribute
+					writer.setSelectionAttribute( 'restrictedEditingException', valueToSet );
 				}
 			} else {
 				for ( const range of ranges ) {

--- a/tests/restrictededitingexceptioncommand.js
+++ b/tests/restrictededitingexceptioncommand.js
@@ -148,7 +148,7 @@ describe( 'RestrictedEditingExceptionCommand', () => {
 			it( 'should remove attribute from text node if a text has the non-restricted attribute (forceValue="false")', () => {
 				setData( model, '<p>abc<$text restrictedEditingException="true">foo[]bar</$text>baz</p>' );
 
-				command.execute();
+				command.execute( { forceValue: false } );
 
 				expect( model.document.selection.hasAttribute( 'restrictedEditingException' ) ).to.be.false;
 				expect( getData( model ) ).to.equal( '<p>abcfoo[]barbaz</p>' );
@@ -157,7 +157,7 @@ describe( 'RestrictedEditingExceptionCommand', () => {
 			it( 'should not remove attribute from text node if a text has the non-restricted attribute (forceValue="true")', () => {
 				setData( model, '<p>abc<$text restrictedEditingException="true">foo[]bar</$text>baz</p>' );
 
-				command.execute();
+				command.execute( { forceValue: true } );
 
 				expect( model.document.selection.hasAttribute( 'restrictedEditingException' ) ).to.be.true;
 				expect( getData( model ) ).to.equal( '<p>abc<$text restrictedEditingException="true">foo[]bar</$text>baz</p>' );

--- a/tests/restrictededitingexceptioncommand.js
+++ b/tests/restrictededitingexceptioncommand.js
@@ -135,13 +135,39 @@ describe( 'RestrictedEditingExceptionCommand', () => {
 				expect( getData( model ) ).to.equal( '<p>abc<$text restrictedEditingException="true">[]foobar</$text>baz</p>' );
 			} );
 
-			it( 'should remove exception when selection is at the end of restricted text', () => {
+			it( 'should remove selection attribute if selection does not have it (selection at the beginning)', () => {
+				setData( model, '<p>abc<$text restrictedEditingException="true">[]foobar</$text>baz</p>' );
+
+				model.change( writer => {
+					writer.setSelectionAttribute( 'restrictedEditingException', 'true' );
+				} );
+
+				command.execute();
+
+				expect( model.document.selection.hasAttribute( 'restrictedEditingException' ) ).to.be.false;
+				expect( getData( model ) ).to.equal( '<p>abc<$text restrictedEditingException="true">[]foobar</$text>baz</p>' );
+			} );
+
+			it( 'should not remove exception when selection is at the end of restricted text', () => {
 				setData( model, '<p>abc<$text restrictedEditingException="true">foobar[]</$text>baz</p>' );
 
 				command.execute();
 
 				expect( model.document.selection.hasAttribute( 'restrictedEditingException' ) ).to.be.false;
-				expect( getData( model ) ).to.equal( '<p>abcfoobar[]baz</p>' );
+				expect( getData( model ) ).to.equal( '<p>abc<$text restrictedEditingException="true">foobar[]</$text>baz</p>' );
+			} );
+
+			it( 'should set selection attribute if selection does not have it (selection at the end)', () => {
+				setData( model, '<p>abc<$text restrictedEditingException="true">foobar[]</$text>baz</p>' );
+
+				model.change( writer => {
+					writer.removeSelectionAttribute( 'restrictedEditingException' );
+				} );
+
+				command.execute();
+
+				expect( model.document.selection.hasAttribute( 'restrictedEditingException' ) ).to.be.true;
+				expect( getData( model ) ).to.equal( '<p>abc<$text restrictedEditingException="true">foobar[]</$text>baz</p>' );
 			} );
 		} );
 

--- a/tests/restrictededitingexceptioncommand.js
+++ b/tests/restrictededitingexceptioncommand.js
@@ -133,6 +133,24 @@ describe( 'RestrictedEditingExceptionCommand', () => {
 				expect( model.document.selection.hasAttribute( 'restrictedEditingException' ) ).to.be.false;
 				expect( getData( model ) ).to.equal( '<p>abcfoo[]barbaz</p>' );
 			} );
+
+			it( 'should not remove exception when selection is at the begining of restricted text', () => {
+				setData( model, '<p>abc<$text restrictedEditingException="true">[]foobar</$text>baz</p>' );
+
+				command.execute();
+
+				expect( model.document.selection.hasAttribute( 'restrictedEditingException' ) ).to.be.true;
+				expect( getData( model ) ).to.equal( '<p>abc<$text restrictedEditingException="true">[]foobar</$text>baz</p>' );
+			} );
+
+			it( 'should remove exception when selection is at the end of restricted text', () => {
+				setData( model, '<p>abc<$text restrictedEditingException="true">foobar[]</$text>baz</p>' );
+
+				command.execute();
+
+				expect( model.document.selection.hasAttribute( 'restrictedEditingException' ) ).to.be.false;
+				expect( getData( model ) ).to.equal( '<p>abcfoobar[]baz</p>' );
+			} );
 		} );
 
 		describe( 'non-collapsed selection', () => {

--- a/tests/restrictededitingexceptioncommand.js
+++ b/tests/restrictededitingexceptioncommand.js
@@ -145,7 +145,7 @@ describe( 'RestrictedEditingExceptionCommand', () => {
 				command.execute();
 
 				expect( model.document.selection.hasAttribute( 'restrictedEditingException' ) ).to.be.false;
-				expect( getData( model ) ).to.equal( '<p>abc<$text restrictedEditingException="true">[]foobar</$text>baz</p>' );
+				expect( getData( model ) ).to.equal( '<p>abc[]<$text restrictedEditingException="true">foobar</$text>baz</p>' );
 			} );
 
 			it( 'should not remove exception when selection is at the end of restricted text', () => {
@@ -154,7 +154,7 @@ describe( 'RestrictedEditingExceptionCommand', () => {
 				command.execute();
 
 				expect( model.document.selection.hasAttribute( 'restrictedEditingException' ) ).to.be.false;
-				expect( getData( model ) ).to.equal( '<p>abc<$text restrictedEditingException="true">foobar[]</$text>baz</p>' );
+				expect( getData( model ) ).to.equal( '<p>abc<$text restrictedEditingException="true">foobar</$text>[]baz</p>' );
 			} );
 
 			it( 'should set selection attribute if selection does not have it (selection at the end)', () => {

--- a/tests/restrictededitingexceptioncommand.js
+++ b/tests/restrictededitingexceptioncommand.js
@@ -134,6 +134,24 @@ describe( 'RestrictedEditingExceptionCommand', () => {
 				expect( getData( model ) ).to.equal( '<p>abcfoo[]barbaz</p>' );
 			} );
 
+			it( 'should add empty exception before when selection is at the begining of text', () => {
+				setData( model, '<p>[]foobar</p>' );
+
+				command.execute();
+
+				expect( model.document.selection.hasAttribute( 'restrictedEditingException' ) ).to.be.true;
+				expect( getData( model ) ).to.equal( '<p><$text restrictedEditingException="true">[]</$text>foobar</p>' );
+			} );
+
+			it( 'should add empty exception after when selection is at the end of text', () => {
+				setData( model, '<p>foobar[]</p>' );
+
+				command.execute();
+
+				expect( model.document.selection.hasAttribute( 'restrictedEditingException' ) ).to.be.true;
+				expect( getData( model ) ).to.equal( '<p>foobar<$text restrictedEditingException="true">[]</$text></p>' );
+			} );
+
 			it( 'should not remove exception when selection is at the begining of restricted text', () => {
 				setData( model, '<p>abc<$text restrictedEditingException="true">[]foobar</$text>baz</p>' );
 

--- a/tests/restrictededitingexceptioncommand.js
+++ b/tests/restrictededitingexceptioncommand.js
@@ -124,6 +124,15 @@ describe( 'RestrictedEditingExceptionCommand', () => {
 
 				expect( model.document.selection.hasAttribute( 'restrictedEditingException' ) ).to.be.false;
 			} );
+
+			it( 'should remove entire selection attribute when inside restricted text', () => {
+				setData( model, '<p>abc<$text restrictedEditingException="true">foo[]bar</$text>baz</p>' );
+
+				command.execute();
+
+				expect( model.document.selection.hasAttribute( 'restrictedEditingException' ) ).to.be.false;
+				expect( getData( model ) ).to.equal( '<p>abcfoo[]barbaz</p>' );
+			} );
 		} );
 
 		describe( 'non-collapsed selection', () => {

--- a/tests/restrictededitingexceptioncommand.js
+++ b/tests/restrictededitingexceptioncommand.js
@@ -131,12 +131,12 @@ describe( 'RestrictedEditingExceptionCommand', () => {
 					writer.setSelectionAttribute( 'restrictedEditingException', true );
 				} );
 
-				expect( model.document.selection.hasAttribute( 'restrictedEditingException' ) ).to.be.true;
-
 				command.execute( { forceValue: true } );
+
+				expect( model.document.selection.hasAttribute( 'restrictedEditingException' ) ).to.be.true;
 			} );
 
-			it( 'should remove attribute from text node if a text has the non-restricted attribute', () => {
+			it( 'should remove an attribute from text node if a text has the non-restricted attribute', () => {
 				setData( model, '<p>abc<$text restrictedEditingException="true">foo[]bar</$text>baz</p>' );
 
 				command.execute();

--- a/tests/restrictededitingexceptioncommand.js
+++ b/tests/restrictededitingexceptioncommand.js
@@ -117,15 +117,7 @@ describe( 'RestrictedEditingExceptionCommand', () => {
 				expect( model.document.selection.hasAttribute( 'restrictedEditingException' ) ).to.be.true;
 			} );
 
-			it( 'should remove the selection attribute if a text has the non-restricted attribute', () => {
-				setData( model, '<p>abc<$text restrictedEditingException="true">foo[]bar</$text>baz</p>' );
-
-				command.execute();
-
-				expect( model.document.selection.hasAttribute( 'restrictedEditingException' ) ).to.be.false;
-			} );
-
-			it( 'should remove entire selection attribute when inside restricted text', () => {
+			it( 'should remove attribute from text node if a text has the non-restricted attribute', () => {
 				setData( model, '<p>abc<$text restrictedEditingException="true">foo[]bar</$text>baz</p>' );
 
 				command.execute();
@@ -134,7 +126,7 @@ describe( 'RestrictedEditingExceptionCommand', () => {
 				expect( getData( model ) ).to.equal( '<p>abcfoo[]barbaz</p>' );
 			} );
 
-			it( 'should add empty exception before when selection is at the begining of text', () => {
+			it( 'should add empty exception before when selection is at the begining of restricted text', () => {
 				setData( model, '<p>[]foobar</p>' );
 
 				command.execute();

--- a/tests/restrictededitingexceptioncommand.js
+++ b/tests/restrictededitingexceptioncommand.js
@@ -126,7 +126,7 @@ describe( 'RestrictedEditingExceptionCommand', () => {
 				expect( getData( model ) ).to.equal( '<p>abcfoo[]barbaz</p>' );
 			} );
 
-			it( 'should add empty exception before when selection is at the begining of restricted text', () => {
+			it( 'should add empty exception before when selection is at the beginning of restricted text', () => {
 				setData( model, '<p>[]foobar</p>' );
 
 				command.execute();
@@ -144,7 +144,7 @@ describe( 'RestrictedEditingExceptionCommand', () => {
 				expect( getData( model ) ).to.equal( '<p>foobar<$text restrictedEditingException="true">[]</$text></p>' );
 			} );
 
-			it( 'should not remove exception when selection is at the begining of restricted text', () => {
+			it( 'should not remove exception when selection is at the beginning of restricted text', () => {
 				setData( model, '<p>abc<$text restrictedEditingException="true">[]foobar</$text>baz</p>' );
 
 				command.execute();

--- a/tests/restrictededitingexceptioncommand.js
+++ b/tests/restrictededitingexceptioncommand.js
@@ -117,6 +117,25 @@ describe( 'RestrictedEditingExceptionCommand', () => {
 				expect( model.document.selection.hasAttribute( 'restrictedEditingException' ) ).to.be.true;
 			} );
 
+			it( 'should not set the selection attribute if there is a text without the attribute (forceValue="false")', () => {
+				setData( model, '<p>abcfoo[]barbaz</p>' );
+
+				command.execute( { forceValue: false } );
+
+				expect( model.document.selection.hasAttribute( 'restrictedEditingException' ) ).to.be.false;
+			} );
+
+			it( 'should not change the selection attribute if selection has the attribute already (forceValue="true")', () => {
+				setData( model, '<p>abcfoo[]barbaz</p>' );
+				model.change( writer => {
+					writer.setSelectionAttribute( 'restrictedEditingException', true );
+				} );
+
+				expect( model.document.selection.hasAttribute( 'restrictedEditingException' ) ).to.be.true;
+
+				command.execute( { forceValue: true } );
+			} );
+
 			it( 'should remove attribute from text node if a text has the non-restricted attribute', () => {
 				setData( model, '<p>abc<$text restrictedEditingException="true">foo[]bar</$text>baz</p>' );
 
@@ -124,6 +143,24 @@ describe( 'RestrictedEditingExceptionCommand', () => {
 
 				expect( model.document.selection.hasAttribute( 'restrictedEditingException' ) ).to.be.false;
 				expect( getData( model ) ).to.equal( '<p>abcfoo[]barbaz</p>' );
+			} );
+
+			it( 'should remove attribute from text node if a text has the non-restricted attribute (forceValue="false")', () => {
+				setData( model, '<p>abc<$text restrictedEditingException="true">foo[]bar</$text>baz</p>' );
+
+				command.execute();
+
+				expect( model.document.selection.hasAttribute( 'restrictedEditingException' ) ).to.be.false;
+				expect( getData( model ) ).to.equal( '<p>abcfoo[]barbaz</p>' );
+			} );
+
+			it( 'should not remove attribute from text node if a text has the non-restricted attribute (forceValue="true")', () => {
+				setData( model, '<p>abc<$text restrictedEditingException="true">foo[]bar</$text>baz</p>' );
+
+				command.execute();
+
+				expect( model.document.selection.hasAttribute( 'restrictedEditingException' ) ).to.be.true;
+				expect( getData( model ) ).to.equal( '<p>abc<$text restrictedEditingException="true">foo[]bar</$text>baz</p>' );
 			} );
 
 			it( 'should not remove exception when selection is at the beginning of restricted text', () => {

--- a/tests/restrictededitingexceptioncommand.js
+++ b/tests/restrictededitingexceptioncommand.js
@@ -172,6 +172,22 @@ describe( 'RestrictedEditingExceptionCommand', () => {
 				expect( getData( model ) ).to.equal( '<p>abc<$text restrictedEditingException="true">[]foobar</$text>baz</p>' );
 			} );
 
+			it( 'should remove attribute from text nodes when other attributes are present', () => {
+				setData( model,
+					'<p>' +
+					'<$text bold="true">abc</$text>' +
+					'<$text bold="true" restrictedEditingException="true">foo[]</$text>' +
+					'<$text restrictedEditingException="true">bar</$text>' +
+					'baz' +
+					'</p>'
+				);
+
+				command.execute();
+
+				expect( model.document.selection.hasAttribute( 'restrictedEditingException' ) ).to.be.false;
+				expect( getData( model ) ).to.equal( '<p><$text bold="true">abcfoo[]</$text>barbaz</p>' );
+			} );
+
 			it( 'should remove selection attribute if selection does not have it (selection at the beginning)', () => {
 				setData( model, '<p>abc<$text restrictedEditingException="true">[]foobar</$text>baz</p>' );
 

--- a/tests/restrictededitingexceptioncommand.js
+++ b/tests/restrictededitingexceptioncommand.js
@@ -126,24 +126,6 @@ describe( 'RestrictedEditingExceptionCommand', () => {
 				expect( getData( model ) ).to.equal( '<p>abcfoo[]barbaz</p>' );
 			} );
 
-			it( 'should add empty exception before when selection is at the beginning of restricted text', () => {
-				setData( model, '<p>[]foobar</p>' );
-
-				command.execute();
-
-				expect( model.document.selection.hasAttribute( 'restrictedEditingException' ) ).to.be.true;
-				expect( getData( model ) ).to.equal( '<p><$text restrictedEditingException="true">[]</$text>foobar</p>' );
-			} );
-
-			it( 'should add empty exception after when selection is at the end of text', () => {
-				setData( model, '<p>foobar[]</p>' );
-
-				command.execute();
-
-				expect( model.document.selection.hasAttribute( 'restrictedEditingException' ) ).to.be.true;
-				expect( getData( model ) ).to.equal( '<p>foobar<$text restrictedEditingException="true">[]</$text></p>' );
-			} );
-
 			it( 'should not remove exception when selection is at the beginning of restricted text', () => {
 				setData( model, '<p>abc<$text restrictedEditingException="true">[]foobar</$text>baz</p>' );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Remove entire exception when collapsed selection is inside text with restricted attribute. Closes https://github.com/ckeditor/ckeditor5/issues/5828.

---

### Additional information

Is it **breaking change**? 🤔 
