### PR TITLE
Add enableCommand method to RestrictedEditingModeEditing.

### DIFF
--- a/src/restrictededitingmode.js
+++ b/src/restrictededitingmode.js
@@ -82,6 +82,9 @@ export default class RestrictedEditingMode extends Plugin {
  *			allowedCommands: [ 'bold', 'italic', 'link', 'unlink' ]
  *		};
  *
+ * To make a command always enabled (also outside non-restricted areas) use
+ * {@link module:restricted-editing/restrictededitingmodeediting~RestrictedEditingModeEditing#enableCommand} method.
+ *
  * @member {Array.<String>} module:restricted-editing/restrictededitingmode~RestrictedEditingModeConfig#allowedCommands
  */
 

--- a/src/restrictededitingmodeediting.js
+++ b/src/restrictededitingmodeediting.js
@@ -112,9 +112,7 @@ export default class RestrictedEditingModeEditing extends Plugin {
 			throw new CKEditorError( 'restricted-editing-command-not-found: Trying to enable command that does not exist.', this );
 		}
 
-		if ( command ) {
-			command.clearForceDisabled( COMMAND_FORCE_DISABLE_ID );
-		}
+		command.clearForceDisabled( COMMAND_FORCE_DISABLE_ID );
 
 		this._alwaysEnabled.add( commandName );
 	}

--- a/src/restrictededitingmodeediting.js
+++ b/src/restrictededitingmodeediting.js
@@ -16,7 +16,6 @@ import {
 	upcastHighlightToMarker
 } from './restrictededitingmode/converters';
 import { getMarkerAtPosition, isSelectionInMarker } from './restrictededitingmode/utils';
-import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
 
 const COMMAND_FORCE_DISABLE_ID = 'RestrictedEditingMode';
 
@@ -103,15 +102,6 @@ export default class RestrictedEditingModeEditing extends Plugin {
 	 */
 	enableCommand( commandName ) {
 		const command = this.editor.commands.get( commandName );
-
-		if ( !command ) {
-			/**
-			 * Trying to enable command that does not exist.
-			 *
-			 * @error restricted-editing-command-not-found
-			 */
-			throw new CKEditorError( 'restricted-editing-command-not-found: Trying to enable command that does not exist.', this );
-		}
 
 		command.clearForceDisabled( COMMAND_FORCE_DISABLE_ID );
 

--- a/src/restrictededitingmodeediting.js
+++ b/src/restrictededitingmodeediting.js
@@ -99,6 +99,9 @@ export default class RestrictedEditingModeEditing extends Plugin {
 	 * Makes the given command always enabled in the restricted editing mode (regardless
 	 * of selection location).
 	 *
+	 * To enable some commands in non-restricted areas of the content use
+	 * {@link module:restricted-editing/restrictededitingmode~RestrictedEditingModeConfig#allowedCommands} configuration option.
+	 *
 	 * @param {String} commandName Name of the command to enable.
 	 */
 	enableCommand( commandName ) {

--- a/src/restrictededitingmodeediting.js
+++ b/src/restrictededitingmodeediting.js
@@ -16,6 +16,9 @@ import {
 	upcastHighlightToMarker
 } from './restrictededitingmode/converters';
 import { getMarkerAtPosition, isSelectionInMarker } from './restrictededitingmode/utils';
+import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
+
+const COMMAND_FORCE_DISABLE_ID = 'RestrictedEditingMode';
 
 /**
  * The Restricted Editing Mode editing feature.
@@ -90,6 +93,30 @@ export default class RestrictedEditingModeEditing extends Plugin {
 				writer.addClass( 'ck-restricted-editing_mode_restricted', root );
 			}
 		} );
+	}
+
+	/**
+	 * Enables command with given `commandName` in restricted editing mode.
+	 *
+	 * @param {String} commandName Name of the command to enable.
+	 */
+	enableCommand( commandName ) {
+		const command = this.editor.commands.get( commandName );
+
+		if ( !command ) {
+			/**
+			 * Trying to enable command that does not exist.
+			 *
+			 * @error restricted-editing-command-not-found
+			 */
+			throw new CKEditorError( 'restricted-editing-command-not-found: Trying to enable command that does not exist.', this );
+		}
+
+		if ( command ) {
+			command.clearForceDisabled( COMMAND_FORCE_DISABLE_ID );
+		}
+
+		this._alwaysEnabled.add( commandName );
 	}
 
 	/**
@@ -264,7 +291,7 @@ export default class RestrictedEditingModeEditing extends Plugin {
 			.map( name => editor.commands.get( name ) );
 
 		for ( const command of commands ) {
-			command.clearForceDisabled( 'RestrictedEditingMode' );
+			command.clearForceDisabled( COMMAND_FORCE_DISABLE_ID );
 		}
 	}
 
@@ -279,7 +306,7 @@ export default class RestrictedEditingModeEditing extends Plugin {
 			.map( name => editor.commands.get( name ) );
 
 		for ( const command of commands ) {
-			command.forceDisabled( 'RestrictedEditingMode' );
+			command.forceDisabled( COMMAND_FORCE_DISABLE_ID );
 		}
 	}
 

--- a/src/restrictededitingmodeediting.js
+++ b/src/restrictededitingmodeediting.js
@@ -96,7 +96,8 @@ export default class RestrictedEditingModeEditing extends Plugin {
 	}
 
 	/**
-	 * Enables command with given `commandName` in restricted editing mode.
+	 * Makes the given command always enabled in the restricted editing mode (regardless
+	 * of selection location).
 	 *
 	 * @param {String} commandName Name of the command to enable.
 	 */

--- a/tests/restrictededitingmodeediting.js
+++ b/tests/restrictededitingmodeediting.js
@@ -9,7 +9,7 @@ import { getData as getModelData, setData as setModelData } from '@ckeditor/cked
 import { getData as getViewData } from '@ckeditor/ckeditor5-engine/src/dev-utils/view';
 import { getCode } from '@ckeditor/ckeditor5-utils/src/keyboard';
 import VirtualTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/virtualtesteditor';
-import { assertEqualMarkup, expectToThrowCKEditorError } from '@ckeditor/ckeditor5-utils/tests/_utils/utils';
+import { assertEqualMarkup } from '@ckeditor/ckeditor5-utils/tests/_utils/utils';
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
 import BoldEditing from '@ckeditor/ckeditor5-basic-styles/src/bold/boldediting';
 import StrikethroughEditing from '@ckeditor/ckeditor5-basic-styles/src/strikethrough/strikethroughediting';
@@ -83,16 +83,6 @@ describe( 'RestrictedEditingModeEditing', () => {
 
 			setModelData( editor.model, '<paragraph>[]foo bar baz qux</paragraph>' );
 			addExceptionMarker( 4, 7, model.document.getRoot().getChild( 0 ) );
-		} );
-
-		it( 'should throw if non-existing command is being enabled', () => {
-			expectToThrowCKEditorError(
-				() => {
-					plugin.enableCommand( 'foo' );
-				},
-				/^restricted-editing-command-not-found/,
-				editor
-			);
 		} );
 
 		it( 'should enable the command globally', () => {

--- a/tests/restrictededitingmodeediting.js
+++ b/tests/restrictededitingmodeediting.js
@@ -9,7 +9,7 @@ import { getData as getModelData, setData as setModelData } from '@ckeditor/cked
 import { getData as getViewData } from '@ckeditor/ckeditor5-engine/src/dev-utils/view';
 import { getCode } from '@ckeditor/ckeditor5-utils/src/keyboard';
 import VirtualTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/virtualtesteditor';
-import { assertEqualMarkup } from '@ckeditor/ckeditor5-utils/tests/_utils/utils';
+import { assertEqualMarkup, expectToThrowCKEditorError } from '@ckeditor/ckeditor5-utils/tests/_utils/utils';
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
 import BoldEditing from '@ckeditor/ckeditor5-basic-styles/src/bold/boldediting';
 import StrikethroughEditing from '@ckeditor/ckeditor5-basic-styles/src/strikethrough/strikethroughediting';
@@ -22,6 +22,7 @@ import RestrictedEditingModeNavigationCommand from '../src/restrictededitingmode
 import ItalicEditing from '@ckeditor/ckeditor5-basic-styles/src/italic/italicediting';
 import BlockQuoteEditing from '@ckeditor/ckeditor5-block-quote/src/blockquoteediting';
 import TableEditing from '@ckeditor/ckeditor5-table/src/tableediting';
+import Command from '@ckeditor/ckeditor5-core/src/command';
 
 describe( 'RestrictedEditingModeEditing', () => {
 	let editor, model;
@@ -60,6 +61,46 @@ describe( 'RestrictedEditingModeEditing', () => {
 			expect(
 				editor.commands.get( 'goToNextRestrictedEditingException' )
 			).to.be.instanceOf( RestrictedEditingModeNavigationCommand );
+		} );
+	} );
+
+	describe( 'enableCommand()', () => {
+		let plugin, command;
+
+		class FakeCommand extends Command {
+			refresh() {
+				this.isEnabled = true;
+			}
+		}
+
+		beforeEach( async () => {
+			editor = await VirtualTestEditor.create( { plugins: [ Paragraph, RestrictedEditingModeEditing ] } );
+			model = editor.model;
+
+			plugin = editor.plugins.get( RestrictedEditingModeEditing );
+			command = new FakeCommand( editor );
+			editor.commands.add( 'fakeCommand', command );
+
+			setModelData( editor.model, '<paragraph>[]foo bar baz qux</paragraph>' );
+			addExceptionMarker( 4, 7, model.document.getRoot().getChild( 0 ) );
+		} );
+
+		it( 'should throw if non-existing command is being enabled', () => {
+			expectToThrowCKEditorError(
+				() => {
+					plugin.enableCommand( 'foo' );
+				},
+				/^restricted-editing-command-not-found/,
+				editor
+			);
+		} );
+
+		it( 'should enable the command globally', () => {
+			expect( command.isEnabled ).to.be.false;
+
+			plugin.enableCommand( 'fakeCommand' );
+
+			expect( command.isEnabled ).to.be.true;
 		} );
 	} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Add enableCommand method to RestrictedEditingModeEditing. Closes ckeditor/ckeditor5#6041. Closes ckeditor/ckeditor5#6011.

---

### Additional information

* This PR add only a `RestrictedEditingModeEditing.enableCommand()` method.
