### PR TITLE
I/5826: Add a helper to handle custom Ctrl+A behaviour

### DIFF
--- a/src/restrictededitingmodeediting.js
+++ b/src/restrictededitingmodeediting.js
@@ -318,7 +318,7 @@ export function onKeyDown( editor, eventInfo, evtData ) {
 	const ctrlA = evtData.ctrlKey && evtData.keyCode === 65;
 
 	// Ctrl+A handler.
-	// If collapsed selection is inside a restricted editing exception, select text only within the exception.
+	// If selection range is inside a restricted editing exception, select text only within the exception.
 	//
 	// Note: Second Ctrl+A will select the entire text in the editor.
 	if ( ctrlA ) {

--- a/tests/restrictededitingmodeediting.js
+++ b/tests/restrictededitingmodeediting.js
@@ -17,7 +17,7 @@ import LinkEditing from '@ckeditor/ckeditor5-link/src/linkediting';
 import Typing from '@ckeditor/ckeditor5-typing/src/typing';
 import Clipboard from '@ckeditor/ckeditor5-clipboard/src/clipboard';
 
-import RestrictedEditingModeEditing, { onSelectAll } from './../src/restrictededitingmodeediting';
+import RestrictedEditingModeEditing from './../src/restrictededitingmodeediting';
 import RestrictedEditingModeNavigationCommand from '../src/restrictededitingmodenavigationcommand';
 import ItalicEditing from '@ckeditor/ckeditor5-basic-styles/src/italic/italicediting';
 import BlockQuoteEditing from '@ckeditor/ckeditor5-block-quote/src/blockquoteediting';
@@ -1388,8 +1388,6 @@ describe( 'RestrictedEditingModeEditing', () => {
 
 			model = editor.model;
 			view = editor.editing.view;
-
-			sinon.spy( onSelectAll );
 		} );
 
 		afterEach( () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Pressing Ctrl+A when selection range is inside an exception selects text only within an exception in restricted editing. Second Ctrl+A selects entire text in the editor. Closes ckeditor/ckeditor5#5826.

