### PR TITLE
i/353: Focus the editor before executing a command

### DIFF
--- a/src/standardeditingmodeui.js
+++ b/src/standardeditingmodeui.js
@@ -42,7 +42,10 @@ export default class StandardEditingModeUI extends Plugin {
 				return value ? t( 'Disable editing' ) : t( 'Enable editing' );
 			} );
 
-			this.listenTo( view, 'execute', () => editor.execute( 'restrictedEditingException' ) );
+			this.listenTo( view, 'execute', () => {
+				editor.execute( 'restrictedEditingException' );
+				editor.editing.view.focus();
+			} );
 
 			return view;
 		} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Focus the editor before executing toolbar buttons' command. 

### Additonal information:
Master PR: https://github.com/ckeditor/ckeditor5/pull/6066
